### PR TITLE
chore(zenodo): add .zenodo.json for automated DOI metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,40 @@
+{
+  "upload_type": "software",
+  "title": "SEMseeker: Stochastic Epigenetic Mutations SEM Seeker",
+  "description": "<p>SEMseeker is an R package for the detection, quantification and association analysis of Stochastic Epigenetic Mutations (SEMs) from DNA methylation data of any source &mdash; Illumina methylation arrays (EPIC 850k, 450k, 27k), whole-genome / reduced-representation bisulfite sequencing (WGBS/RRBS), and long-read sequencing (Oxford Nanopore, PacBio) consumed either as bedmethyl files or as any BAM with per-site methylation calls. It computes binary SEM calls and continuous deviation metrics (DeltaR, DeltaRP, DeltaRQ), aggregates mutations into genomic lesions, and provides downstream association analysis and pathway enrichment via multiple backends (WebGestalt, STRINGdb, pathfindR, CTD).</p><p>Documentation and landing page: <a href=\"https://drake69.github.io/SEMseeker/\">https://drake69.github.io/SEMseeker/</a></p>",
+  "creators": [
+    {
+      "name": "Corsaro, Luigi",
+      "orcid": "0000-0003-1218-230X",
+      "affiliation": "Centro Diagnostico Italiano S.p.A., Milan, Italy"
+    }
+  ],
+  "license": "AGPL-3.0-or-later",
+  "access_right": "open",
+  "keywords": [
+    "DNA methylation",
+    "epigenetics",
+    "stochastic epigenetic mutations",
+    "SEM",
+    "epigenomics",
+    "Illumina methylation array",
+    "EPIC 850k",
+    "whole-genome bisulfite sequencing",
+    "Oxford Nanopore",
+    "pathway enrichment",
+    "bioinformatics",
+    "R package"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://drake69.github.io/SEMseeker/",
+      "relation": "isDocumentedBy",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://github.com/drake69/SEMseeker",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.zenodo.json` so Zenodo populates release deposits automatically once the GitHub↔Zenodo webhook is enabled.

Metadata included:
- **title / description** of SEMseeker (with landing page https://drake69.github.io/SEMseeker/)
- **creator**: Luigi Corsaro (ORCID 0000-0003-1218-230X), affiliation Centro Diagnostico Italiano S.p.A.
- **license**: AGPL-3.0-or-later
- **keywords** (methylation / epigenetics / SEM / …)
- **related_identifiers**: pkgdown landing page + GitHub repo

Prerequisite for the next release (v0.99.4) to receive an automatic Zenodo DOI. No code changes.