### PR TITLE
ci: fix three failing scheduled workflows

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -57,8 +57,22 @@ jobs:
           add("- Running: R ", r_current)
 
           # ── Bioconductor version ──
-          lf <- renv:::renv_lockfile_read("renv.lock")
-          bioc_urls <- grep("bioconductor.org", sapply(lf$R$Repositories, `[[`, "URL"), value = TRUE)
+          # Guard every access: a lockfile whose Repositories entries lack a
+          # "URL" key would make sapply(`[[`, "URL") throw "subscript out of
+          # bounds" and fail the whole step (seen 2026-06/07). Extract URLs
+          # defensively and default to an empty vector on any error.
+          bioc_urls <- tryCatch({
+            lf <- renv:::renv_lockfile_read("renv.lock")
+            repos <- lf$R$Repositories
+            if (is.null(repos)) character(0) else {
+              urls <- vapply(
+                repos,
+                function(x) if (!is.null(x[["URL"]])) as.character(x[["URL"]]) else NA_character_,
+                character(1)
+              )
+              grep("bioconductor.org", urls, value = TRUE)
+            }
+          }, error = function(e) character(0))
           if (length(bioc_urls) > 0) {
             bioc_lock <- sub(".*/packages/([0-9.]+)/.*", "\\1", bioc_urls[1])
             add("- Bioconductor in lockfile: ", bioc_lock)

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -19,10 +19,22 @@ jobs:
           fetch-depth: 1
 
       - name: Fetch traffic from GitHub API
+        # The traffic API (clones/views) requires repo ADMIN access, which the
+        # default GITHUB_TOKEN integration token cannot have (HTTP 403
+        # "Resource not accessible by integration"). Use a PAT with
+        # "Administration: read" (fine-grained) or `repo` scope (classic),
+        # stored as the TRAFFIC_TOKEN secret. If the secret is absent the job
+        # skips cleanly (neutral, not red) instead of failing every week.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
           mkdir -p traffic
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::TRAFFIC_TOKEN secret not set — skipping traffic archival. Add a PAT (Administration: read) as the TRAFFIC_TOKEN secret to enable weekly archival."
+            echo '{"clones":[]}' > /tmp/clones_new.json
+            echo '{"views":[]}'  > /tmp/views_new.json
+            exit 0
+          fi
           gh api repos/${{ github.repository }}/traffic/clones > /tmp/clones_new.json
           gh api repos/${{ github.repository }}/traffic/views  > /tmp/views_new.json
 

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Fetch traffic from GitHub API
+        id: fetch
         # The traffic API (clones/views) requires repo ADMIN access, which the
         # default GITHUB_TOKEN integration token cannot have (HTTP 403
         # "Resource not accessible by integration"). Use a PAT with
@@ -28,17 +29,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
-          mkdir -p traffic
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::TRAFFIC_TOKEN secret not set — skipping traffic archival. Add a PAT (Administration: read) as the TRAFFIC_TOKEN secret to enable weekly archival."
-            echo '{"clones":[]}' > /tmp/clones_new.json
-            echo '{"views":[]}'  > /tmp/views_new.json
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          mkdir -p traffic
           gh api repos/${{ github.repository }}/traffic/clones > /tmp/clones_new.json
           gh api repos/${{ github.repository }}/traffic/views  > /tmp/views_new.json
 
       - name: Merge into archive (deduplicate by timestamp)
+        if: steps.fetch.outputs.skip != 'true'
         run: |
           # Initialise archive files on first run
           [ -f traffic/clones.json ] || echo '[]' > traffic/clones.json
@@ -67,6 +68,7 @@ jobs:
           mv /tmp/views_merged.json  traffic/views.json
 
       - name: Show summary
+        if: steps.fetch.outputs.skip != 'true'
         run: |
           echo "### Clones archive"
           jq 'length' traffic/clones.json
@@ -78,6 +80,7 @@ jobs:
           jq '.[-3:]' traffic/views.json
 
       - name: Commit if changed
+        if: steps.fetch.outputs.skip != 'true'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+# gitleaks configuration for SEMseeker
+#
+# Inherits all default gitleaks rules, then allowlists known-public false
+# positives so the scheduled `security` workflow (full-history scan) does not
+# fail on non-secrets. Keep this allowlist TIGHT: only allowlist values that
+# are public by design, so any genuinely new secret still fails the scan.
+
+title = "SEMseeker gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = """
+Vemetric web-analytics site token (`data-token`) embedded in the pkgdown site
+header (_pkgdown.yml) and propagated into every generated HTML page. It is a
+client-side ingestion token served to every visitor's browser — public by
+design, not a secret. This accounts for all 103 `generic-api-key` findings in
+the *.html files and _pkgdown.yml.
+"""
+regexTarget = "line"
+regexes = [
+  '''nWIrdnyvzA1sksDn''',
+]


### PR DESCRIPTION
Fixes the three red periodic Actions.

## 1. `security` / gitleaks — failing weekly
Full-history scan flagged **103 `generic-api-key` findings**, all the *same* value: the public **Vemetric analytics `data-token`** (`_pkgdown.yml:12`) propagated into every generated `*.html` page. It's a client-side ingestion token served to every visitor — public by design, **not a secret** (verified via the run's SARIF: single distinct value, all in generated HTML). Added `.gitleaks.toml` allowlisting *only* that token (`regexTarget = line`), so any genuinely new secret still fails.

## 2. `Archive traffic data` — failing weekly (HTTP 403)
`gh api .../traffic/clones` → `Resource not accessible by integration`. The traffic API needs repo **admin** access the default `GITHUB_TOKEN` cannot have. Switched to a **`TRAFFIC_TOKEN` PAT secret**; if it's absent the job now **skips cleanly (neutral, not red)**.

⚠️ **Action required to fully enable:** create a PAT (fine-grained *Administration: read*, or classic `repo`) and add it as repo secret `TRAFFIC_TOKEN`. Until then the workflow is green-skipped.

## 3. `dependency-check` — intermittent failure
`Error in FUN(...): subscript out of bounds` from `sapply(lf$R$Repositories, `[[`, "URL")` when a lockfile repo entry lacks a `URL` key (unguarded). Hardened the extraction with `vapply` + `tryCatch` defaulting to empty.

No package code touched — CI/workflows only.