### PR TITLE
feat: mandatory coverage gate, sample-id normalisation, burden guard + test expansion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,27 @@
 
 ## semseeker 0.99.3
 
+### New features
+
+- **Coverage is now a mandatory pre-step of every SEM analysis (AI-074).**
+  Coverage used to be an opt-in report, so a run could go straight to SEM
+  detection on input that barely overlaps the reference annotation (long-read
+  positions against an Illumina manifest, a batch with a probe mismatch, the
+  wrong genome build) and produce thresholds computed on a handful of probes.
+  Every run now: writes the coverage charts, logs a coverage banner
+  (`input_positions` / `covered_by_reference` / percentage), writes a
+  `COVERAGE_GATE.json` sidecar for audit, and **stops** when coverage falls
+  below the new `coverage_minimum` parameter (default 80%). The charts are
+  produced even when the gate rejects the run — they are what shows which
+  regions were missing. Coordinate-based technologies (WGBS, long reads)
+  derive their annotation from the positions themselves, so the threshold is
+  not applied there. Lower `coverage_minimum` explicitly for deliberate
+  cross-technology runs.
+- The coverage charts are now computed over the full annotation set instead of
+  the areas selected for the run. `areas` defaults to `POSITION` only, which
+  the coverage report skips, so on a default run the charts were previously
+  never produced.
+
 ### Documentation
 
 - Aligned the delta-metric documentation in the vignettes and README with the
@@ -10,8 +31,40 @@
   quantile ranked variants. Corrected the pivot file-name examples to
   `Data/Pivots/<MARKER>/<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<build>.parquet` and
   updated a stale `enrichment_analysis()` reference.
+- `inst/CITATION` now carries the Zenodo DOI `10.5281/zenodo.5095417` instead
+  of a Bioconductor DOI that does not resolve (the package is not on
+  Bioconductor yet), and the README no longer says a Zenodo DOI "will be
+  registered" — the archive has existed since 2021 (AI-119).
 
 ### Bug fixes
+
+- **A sample sheet that shares no identifier with the computed pivots no
+  longer produces a silently empty result (AI-083).**
+  `sem_study_summary_total()` merged the per-sample burden onto the sample
+  sheet by name with `all.x = TRUE`: when the two sides had no identifier in
+  common, every burden column landed as `NA` while `PROBES_COUNT` stayed
+  populated, and each `depth = 1` inference downstream then failed with
+  "data are not the same size". The merge now stops with a message naming
+  both sides, and reports partially missing samples as a warning. The
+  accumulator inside the function is also a proper local binding now: it was
+  resolved with `exists()`, which reaches the global environment.
+- The same `exists()` pattern was removed from `sem_coverage_analysis()`,
+  which could also raise "object 'tot_result' not found" when no area
+  produced a usable table.
+
+- **Sample identifiers containing `-`, `.` or spaces are now handled correctly
+  (AI-224).** Sample-column names of the signal matrix are normalised
+  (uppercase, non-alphanumeric characters replaced by `_`), but the sample
+  sheet identifiers were used as-is when selecting those columns. With
+  identifiers such as `C3L-00001-06` the two sides never matched:
+  `util_exploratory_analysis()` wrote a cleaned signal parquet holding the
+  `PROBE` column only, and the SEM pipeline stopped with
+  `undefined columns selected`. Datasets whose identifiers are already
+  alphanumeric (e.g. `GSM123456`) were unaffected. Both sides are now
+  normalised through a single, idempotent internal helper before any
+  name-based column selection; distinct identifiers that would collapse onto
+  the same normalised name, and identifiers without a matching signal column,
+  are reported explicitly instead of failing later.
 
 - **`plot_box_plot()`: fixed R CMD check ERROR under ggplot2 >= 4.0.**
   `ggpubr::stat_compare_means(label = "p.format")` builds an internal

--- a/R/core_init_env.R
+++ b/R/core_init_env.R
@@ -35,6 +35,7 @@
   showprogress           = list(value = FALSE),
   openai_api_key         = list(value = ""),
   multiple_test_adj      = list(value = "q", choices = c("BY","fdr","BH","bonferroni","q")),
+  coverage_minimum       = list(value = 80),      # AI-074: minimum % of input positions that must be present in the reference annotation; below it sem_coverage_gate() stops the run.
   bulk_population        = list(value = TRUE)    # AI-042: vectorized population is the default (no per-sample bed dump). Set FALSE only to core_recover the legacy per-sample loop.
 )
 

--- a/R/core_normalize_sample_ids.R
+++ b/R/core_normalize_sample_ids.R
@@ -1,0 +1,120 @@
+#' Normalise sample identifiers on both sides of the pipeline (internal)
+#'
+#' Single point of truth for sample-identifier normalisation. Every entry point
+#' that receives a user-supplied sample sheet together with a signal matrix must
+#' route both through this helper BEFORE any column subsetting.
+#'
+#' Background (AI-224): the pipeline cleans `colnames(signal_data)` with
+#' [core_name_cleaning()] (uppercase, non-alphanumeric -> "_") but historically
+#' compared/subset those columns with the RAW `Sample_ID` values coming from the
+#' sample sheet. With identifiers containing "-", "." or spaces the match is
+#' empty and R fails with the opaque `undefined columns selected`, or - worse -
+#' silently produces an empty result (`%in%` filters). The bug stayed invisible
+#' because the reference datasets use `GSM\\d+` identifiers, on which
+#' [core_name_cleaning()] is a no-op.
+#'
+#' The transformation is idempotent: applying it twice yields the same result,
+#' so calling this helper again downstream is always safe.
+#'
+#' @param sample_sheet Data frame with a sample-identifier column.
+#' @param signal_data Optional matrix / data frame whose columns are samples
+#'   (probe identifiers live in the rownames). Structural columns are left
+#'   untouched.
+#' @param sample_id_column Name of the identifier column (default
+#'   `"Sample_ID"`).
+#' @param require_all_ids If `TRUE`, every sample-sheet identifier must have a
+#'   matching column in `signal_data`, otherwise the call fails with an explicit
+#'   message listing the offenders. Use it right before any positional/name
+#'   subsetting of `signal_data`.
+#' @param structural_columns Column names that are NOT samples and must be
+#'   preserved as-is.
+#'
+#' @return A list with the normalised `sample_sheet` and `signal_data`, plus
+#'   `unmatched_ids` (sample-sheet identifiers with no signal column) and
+#'   `unmatched_columns` (signal columns absent from the sample sheet).
+#'
+#' @keywords internal
+#' @noRd
+core_normalize_sample_ids <- function(sample_sheet,
+                                      signal_data = NULL,
+                                      sample_id_column = "Sample_ID",
+                                      require_all_ids = FALSE,
+                                      structural_columns = c("PROBE", "AREA", "CHR", "START", "END")) {
+
+  if (!is.null(sample_sheet)) {
+    if (!is.data.frame(sample_sheet))
+      sample_sheet <- as.data.frame(sample_sheet, stringsAsFactors = FALSE)
+    if (!(sample_id_column %in% colnames(sample_sheet)))
+      stop("core_normalize_sample_ids(): the sample sheet has no '",
+           sample_id_column, "' column. Available columns: ",
+           paste(colnames(sample_sheet), collapse = ", "))
+
+    raw_ids <- as.character(sample_sheet[, sample_id_column])
+    clean_ids <- core_name_cleaning(raw_ids)
+    .core_stop_on_id_collision(raw_ids, clean_ids, "sample sheet")
+    sample_sheet[, sample_id_column] <- clean_ids
+  } else {
+    clean_ids <- character(0)
+  }
+
+  if (!is.null(signal_data) && !is.null(colnames(signal_data))) {
+    raw_cols <- colnames(signal_data)
+    is_structural <- raw_cols %in% structural_columns
+    clean_cols <- raw_cols
+    clean_cols[!is_structural] <- core_name_cleaning(raw_cols[!is_structural])
+    .core_stop_on_id_collision(raw_cols[!is_structural],
+                               clean_cols[!is_structural],
+                               "signal data columns")
+    colnames(signal_data) <- clean_cols
+  }
+
+  sample_columns <- if (is.null(signal_data)) character(0) else
+    setdiff(colnames(signal_data), structural_columns)
+
+  unmatched_ids <- setdiff(unique(clean_ids), sample_columns)
+  unmatched_columns <- setdiff(sample_columns, unique(clean_ids))
+
+  if (isTRUE(require_all_ids) && !is.null(signal_data) && length(unmatched_ids) > 0)
+    stop("core_normalize_sample_ids(): ", length(unmatched_ids),
+         " sample sheet identifier(s) have no matching column in the signal data ",
+         "even after normalisation: ",
+         paste(utils::head(unmatched_ids, 10), collapse = ", "),
+         if (length(unmatched_ids) > 10) ", ..." else "",
+         ". First signal data columns: ",
+         paste(utils::head(sample_columns, 4), collapse = ", "), ".")
+
+  list(sample_sheet = sample_sheet,
+       signal_data = signal_data,
+       unmatched_ids = unmatched_ids,
+       unmatched_columns = unmatched_columns)
+}
+
+#' Fail when normalisation collapses distinct identifiers onto the same name
+#'
+#' Forcing [core_name_cleaning()] on user-supplied identifiers can merge two
+#' distinct samples (e.g. `"S-1"` and `"S.1"` both become `"S_1"`). That would
+#' silently mix samples, so it is always an error.
+#'
+#' @keywords internal
+#' @noRd
+.core_stop_on_id_collision <- function(raw, clean, origin) {
+  if (length(raw) == 0) return(invisible(NULL))
+  keep <- !is.na(raw) & !is.na(clean)
+  raw <- raw[keep]; clean <- clean[keep]
+  if (length(raw) == 0) return(invisible(NULL))
+
+  n_distinct <- tapply(raw, clean, function(x) length(unique(x)))
+  colliding <- names(n_distinct)[n_distinct > 1]
+  if (length(colliding) == 0) return(invisible(NULL))
+
+  details <- vapply(colliding, function(cl) {
+    paste0(cl, " <- {", paste(sort(unique(raw[clean == cl])), collapse = ", "), "}")
+  }, character(1))
+
+  stop("core_normalize_sample_ids(): name normalisation collapses distinct ",
+       origin, " identifiers onto the same name: ",
+       paste(utils::head(details, 5), collapse = "; "),
+       if (length(details) > 5) ", ..." else "",
+       ". Rename them upstream so they stay distinct after ",
+       "uppercase + non-alphanumeric replacement.")
+}

--- a/R/io_signal_save.R
+++ b/R/io_signal_save.R
@@ -16,6 +16,14 @@ io_signal_save <- function(signal_data, sample_sheet, batch_id,
     return()
   }
 
+  # AI-224: normalise both sides and fail with the offending identifiers rather
+  # than with R's "undefined columns selected" on the subset below.
+  .normalized <- core_normalize_sample_ids(sample_sheet, signal_data,
+                                           require_all_ids = TRUE)
+  sample_sheet <- .normalized$sample_sheet
+  signal_data  <- .normalized$signal_data
+  rm(.normalized)
+
   signal_data <- signal_data[, unique(sample_sheet$Sample_ID), drop = FALSE]
 
   # ------------------------------------------------------------------

--- a/R/sem_analyze_batch.R
+++ b/R/sem_analyze_batch.R
@@ -30,7 +30,9 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
  
   ssEnv <- core_get_session_info()
   batch_id <- ssEnv$running_batch_id
-  sample_sheet$Sample_ID <- core_name_cleaning(sample_sheet$Sample_ID)
+  # AI-224: idempotent — sem_core() already normalised the sheet, but
+  # sem_analyze_batch() is also called directly (tests, resume tooling).
+  sample_sheet <- core_normalize_sample_ids(sample_sheet)$sample_sheet
 
   # AI-027: read via unified dispatcher. CASE 2 (streaming merge) lets
   # the SEM step pick up raw bed/bedgraph files when the SIGNAL_MEAN
@@ -117,6 +119,11 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
     core_log_event("DEBUG_MEM: ", format(Sys.time(), "%a %b %d %X %Y"),
               " post-probe_ids_collect mem_MB=", round(sum(gc()[, "(Mb)"]), 1),
               " n_probe_ids=", length(probe_ids_vec))
+
+    # AI-074: the gate applies to the resume path too — resuming from a SIGNAL
+    # pivot still runs the SEM detection downstream.
+    sem_coverage_gate(probe_ids_vec)
+
     if (ssEnv$tech %in% c("WGBS", "LONGREAD")) {
       probe_features <- io_coord_probe_features(probe_ids_vec)
     } else {
@@ -253,7 +260,10 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
             " working on batch:", batch_id, " of ", nrow(signal_data),
             " rows and ", ncol(signal_data), " samples (fresh mode).")
-  colnames(signal_data) <- core_name_cleaning(colnames(signal_data))
+  # AI-224: normalise the signal columns with the SAME function used on the
+  # sheet identifiers, so the name-based subsetting below cannot silently miss.
+  signal_data <- core_normalize_sample_ids(sample_sheet = NULL,
+                                           signal_data = signal_data)$signal_data
 
   # Transparent conversion: WGBS/LONGREAD coordinate input → synthetic probe IDs
   signal_data <- io_normalize_signal_input(signal_data)
@@ -265,6 +275,10 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
 
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
             " I will work on:", nrow(signal_data), " PROBES.")
+
+  # AI-074: mandatory coverage gate — charts are produced on every run and the
+  # run stops when the input barely overlaps the reference annotation.
+  sem_coverage_gate(rownames(signal_data))
 
   # AI-106+ (2026-06-09): single source of truth for input → annotation
   # alignment. sem_prepare_batch_signal() centralises:
@@ -293,6 +307,11 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
   if (!is.null(sample_group_checkResult)) {
     stop(sample_group_checkResult)
   }
+
+  # AI-224: last gate before every name-based column subset below
+  # (io_signal_save, reference matrix, per-population matrices). Fails with the
+  # offending identifiers instead of R's opaque "undefined columns selected".
+  core_normalize_sample_ids(sample_sheet, signal_data, require_all_ids = TRUE)
 
   io_signal_save(signal_data, sample_sheet, batch_id, probe_features = probe_features)
   core_log_event("DEBUG_MEM: ", format(Sys.time(), "%a %b %d %X %Y"),

--- a/R/sem_analyze_population.R
+++ b/R/sem_analyze_population.R
@@ -28,6 +28,13 @@ sem_analyze_population <- function(signal_data, sample_sheet,signal_thresholds, 
   }
 
   ### get signal_values ########################################################
+  # AI-224: idempotent normalisation of both sides — the per-sample subset
+  # below is name-based and must not depend on the caller having cleaned them.
+  .normalized <- core_normalize_sample_ids(sample_sheet, signal_data)
+  sample_sheet <- .normalized$sample_sheet
+  signal_data  <- .normalized$signal_data
+  rm(.normalized)
+
   sample_sheet <- sample_sheet[order(sample_sheet[, "Sample_ID"], decreasing = FALSE), ]
   existent_samples <- colnames(signal_data)
   sample_names <- sample_sheet$Sample_ID

--- a/R/sem_core.R
+++ b/R/sem_core.R
@@ -43,7 +43,11 @@ sem_core <- function(sample_sheet,
     ssEnv$running_batch_id <- batch_id
     ssEnv <- core_update_session_info(ssEnv)
     sample_sheet_local <- io_source_data_get(sample_sheet[[batch_id]])
-    sample_sheet_local$Sample_ID <- core_name_cleaning(sample_sheet_local$Sample_ID)
+    # AI-224: single normalisation point for the sheet side. The signal side is
+    # normalised inside sem_analyze_batch(), where the matrix is materialised
+    # (keeping it there avoids holding a second reference to a multi-GB object
+    # alive in this frame for the whole batch).
+    sample_sheet_local <- core_normalize_sample_ids(sample_sheet_local)$sample_sheet
     utils::write.csv2(sample_sheet_local, file = io_file_path_build(ssEnv$result_folderData, paste0(batch_id,"_sample_sheet_original"),"csv",FALSE))
     sem_analyze_batch(io_source_data_get(signal_data[[batch_id]]), sample_sheet_local)
     anno_create_position_pivots(sample_sheet_local,ssEnv$keys_markers_figures)

--- a/R/sem_coverage_analysis.R
+++ b/R/sem_coverage_analysis.R
@@ -1,11 +1,24 @@
-sem_coverage_analysis <- function(observed_probes)
+#' @param observed_probes character. Probe identifiers present in the input.
+#' @param keys data.frame of AREA / SUBAREA (optionally COMBINED) to report on.
+#'   Defaults to the areas selected for the run. AI-074 passes the FULL
+#'   annotation set here: `areas` defaults to POSITION only
+#'   (util_keys_create.R:83) and this function skips POSITION and PROBE, so on
+#'   a default run the session keys are empty and no chart was ever produced.
+#'   The coverage picture must not depend on which areas the run analyses.
+#' @keywords internal
+#' @noRd
+sem_coverage_analysis <- function(observed_probes, keys = NULL)
 {
   # probe_features <- PROBES_CHR_CHR
   # area <- c("CHR")
   # probes_prefix <- "PROBES_CHR_"
   ssEnv <- core_get_session_info()
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"), " Started Coverage analysis.")
-  keys <- ssEnv$keys_areas_subareas
+  if (is.null(keys))
+    keys <- ssEnv$keys_areas_subareas
+  if (!is.null(keys) && nrow(keys) > 0 && !("COMBINED" %in% colnames(keys)))
+    keys$COMBINED <- apply(keys[, c("AREA", "SUBAREA")], 1, function(x)
+      core_name_cleaning(gsub(" ", "", paste0(x[x != ""], collapse = "_"))))
   keys <- keys[keys$AREA != "POSITION",]
   keys <- keys[keys$AREA != "PROBE",]
   if(plyr::empty(keys))
@@ -13,6 +26,14 @@ sem_coverage_analysis <- function(observed_probes)
     core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"), " No keys found for coverage analysis.")
     return()
   }
+  # AI-074: local accumulators. The previous exists()-based logic resolved
+  # through globalenv(), so an object of the same name left in an interactive
+  # session changed the result — same defect class fixed in
+  # sem_study_summary_total() under AI-083. Now that coverage runs on EVERY SEM
+  # analysis this function must be deterministic.
+  cov_result <- NULL
+  tot_result <- NULL
+
   for ( k in seq_len(nrow(keys)))
   {
     # k <- 16
@@ -24,8 +45,7 @@ sem_coverage_analysis <- function(observed_probes)
       area_subarea <- paste(area_subarea,"_","WHOLE",sep="")
 
     # core_log_event(area,"\n")
-    if(exists("covered_count"))
-      rm(covered_count)
+    covered_count <- NULL
 
     probe_features <- anno_probe_features_get(area_subarea)
     if(plyr::empty(probe_features) | nrow(probe_features)==0)
@@ -63,7 +83,7 @@ sem_coverage_analysis <- function(observed_probes)
 
     cov_stat$AREA <- area
     cov_stat$SUBAREA <- subarea
-    if(exists("cov_result"))
+    if(!is.null(cov_result))
       cov_result <- rbind(cov_result, cov_stat)
     else
       cov_result <- cov_stat
@@ -72,14 +92,17 @@ sem_coverage_analysis <- function(observed_probes)
     total_count$AREA <- area
     total_count$SUBAREA <- subarea
 
-    if(exists("tot_result"))
+    if(!is.null(tot_result))
       tot_result <- rbind(total_count, tot_result)
     else
       tot_result <- total_count
 
   }
 
-  if(nrow(tot_result)<1)
+  # No area produced a usable table (e.g. tech without Illumina annotation):
+  # nothing to plot. Previously this line dereferenced a possibly non-existent
+  # tot_result and raised "object 'tot_result' not found".
+  if(is.null(tot_result) || nrow(tot_result)<1 || is.null(cov_result))
     return()
 
   chartFolder <- io_dir_check_and_create(ssEnv$result_folderChart,"COVERAGE")

--- a/R/sem_coverage_gate.R
+++ b/R/sem_coverage_gate.R
@@ -1,0 +1,128 @@
+#' Mandatory coverage check run before every SEM analysis (internal)
+#'
+#' AI-074. Coverage used to be an opt-in report: any pipeline path could go
+#' straight to the SEM rebuild on signal data that has little or no overlap
+#' with the reference annotation (Nanopore input against an Illumina manifest,
+#' a batch with a probe mismatch, the wrong genome build). The run then
+#' produced thresholds computed on a handful of probes and every downstream
+#' number was quietly wrong.
+#'
+#' This gate always runs, in this order:
+#' \enumerate{
+#'   \item the coverage charts (\code{\link{sem_coverage_analysis}}) are
+#'     generated on EVERY run, whatever the verdict — they are the artefact the
+#'     analyst reads to understand what was covered;
+#'   \item a global coverage percentage (input positions found in the reference
+#'     annotation) is logged as a BANNER and written to a JSON sidecar for
+#'     later audit;
+#'   \item the run STOPS when coverage is below \code{coverage_minimum}
+#'     (default 80\%), naming the numbers involved.
+#' }
+#'
+#' Coordinate-based technologies (WGBS / long reads) derive their annotation
+#' from the positions themselves, so the overlap is 100\% by construction and
+#' the threshold is not applied; the charts are still attempted and the JSON
+#' sidecar still written, with \code{gate = "skipped"}.
+#'
+#' @param observed_probes character. Probe / position identifiers of the input.
+#' @param tech character. Technology label; defaults to the session value.
+#'
+#' @return Invisibly the list of coverage metrics.
+#' @keywords internal
+#' @noRd
+sem_coverage_gate <- function(observed_probes, tech = NULL) {
+
+  ssEnv <- core_get_session_info()
+  if (is.null(tech)) tech <- ssEnv$tech
+  tech <- if (is.null(tech)) "" else as.character(tech)
+
+  observed_probes <- unique(as.character(observed_probes))
+  n_input <- length(observed_probes)
+
+  minimum <- suppressWarnings(as.numeric(ssEnv$coverage_minimum))
+  if (length(minimum) != 1L || is.na(minimum)) minimum <- 80
+
+  # ---- (1) charts ALWAYS, whatever the verdict -----------------------------
+  # A plotting failure must never take down a SEM run: log it and carry on to
+  # the numeric gate, which is the part that protects the results.
+  # Report on the FULL annotation set, not on ssEnv$keys_areas_subareas: the
+  # latter is filtered down to the areas the run analyses (POSITION only by
+  # default), which would leave the charts empty on a default run.
+  keys_all <- ssEnv$default$keys_areas_subareas_default
+  tryCatch(
+    sem_coverage_analysis(observed_probes, keys = keys_all),
+    error = function(e)
+      core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"),
+                " Coverage charts could not be generated: ",
+                conditionMessage(e))
+  )
+
+  # ---- (2) global coverage -------------------------------------------------
+  coord_tech <- tech %in% c("WGBS", "LONGREAD")
+  n_covered <- NA_integer_
+  pct <- NA_real_
+  verdict <- "skipped"
+
+  if (coord_tech) {
+    core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " Coverage gate not applicable to tech '", tech,
+              "': positions carry their own coordinates, overlap is 100% by construction.")
+    n_covered <- n_input
+    pct <- 100
+  } else {
+    reference <- tryCatch(anno_probe_features_get("PROBE"),
+                          error = function(e) NULL)
+    if (is.null(reference) || nrow(reference) == 0) {
+      core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+                " Coverage gate could not load the probe annotation for tech '",
+                tech, "' / build '", ssEnv$genome_build,
+                "': the gate is not enforced for this run.")
+    } else {
+      n_covered <- sum(observed_probes %in% as.character(reference$PROBE))
+      pct <- if (n_input > 0) 100 * n_covered / n_input else 0
+      verdict <- if (pct >= minimum) "pass" else "fail"
+    }
+  }
+
+  metrics <- list(
+    tech             = tech,
+    genome_build     = if (is.null(ssEnv$genome_build)) NA_character_ else ssEnv$genome_build,
+    input_positions  = n_input,
+    covered_positions = n_covered,
+    coverage_percent = if (is.na(pct)) NA_real_ else round(pct, 2),
+    coverage_minimum = minimum,
+    gate             = verdict
+  )
+
+  core_log_event("BANNER: ", format(Sys.time(), "%a %b %d %X %Y"),
+            " Coverage — input_positions=", n_input,
+            " | covered_by_reference=", n_covered,
+            " | coverage=", if (is.na(pct)) "NA" else paste0(round(pct, 2), "%"),
+            " | minimum=", minimum, "%",
+            " | gate=", verdict)
+
+  # ---- (3) JSON sidecar for later audit ------------------------------------
+  tryCatch({
+    sidecar <- io_file_path_build(ssEnv$result_folderData, "coverage_gate", "json")
+    writeLines(jsonlite::toJSON(metrics, auto_unbox = TRUE, pretty = TRUE), sidecar)
+  }, error = function(e)
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " Coverage sidecar not written: ", conditionMessage(e)))
+
+  # ---- (4) verdict ---------------------------------------------------------
+  if (identical(verdict, "fail")) {
+    msg <- paste0(
+      "Coverage gate failed: only ", n_covered, " of ", n_input,
+      " input positions (", round(pct, 2), "%) are present in the reference ",
+      "annotation for tech '", tech, "' / genome_build '", ssEnv$genome_build,
+      "', below the required ", minimum, "%. This usually means the input does ",
+      "not match the declared technology or genome build. Fix the input, or ",
+      "lower the threshold explicitly with coverage_minimum = <value> if a ",
+      "partial overlap is expected (e.g. a deliberate cross-technology run)."
+    )
+    core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"), " ", msg)
+    stop(msg)
+  }
+
+  invisible(metrics)
+}

--- a/R/sem_semseeker.R
+++ b/R/sem_semseeker.R
@@ -42,6 +42,10 @@
 #'   (default 2000) is the maximum bp distance between two probes for them to
 #'   be in the same LESIONS enrichment window — replaces the legacy
 #'   \code{sliding_window_size} probe-count parameter (removed in AI-092).
+#'   \code{coverage_minimum} (default 80) is the minimum percentage of input
+#'   positions that must be present in the reference annotation: the coverage
+#'   charts are written on every run, and the run stops below this threshold
+#'   (AI-074). Lower it explicitly for deliberate cross-technology runs.
 #'
 #' @return Invisibly \code{NULL}; writes output files to \code{result_folder}.
 #'

--- a/R/sem_study_summary_total.R
+++ b/R/sem_study_summary_total.R
@@ -9,6 +9,16 @@ sem_study_summary_total <- function()
   keys <- subset(keys, AREA=="POSITION")
   if(nrow(keys)==0)
     return()
+
+  # AI-083: temp_result MUST be a local binding initialised here. The previous
+  # code used exists("temp_result"), which resolves through the enclosing
+  # environments up to globalenv(): a leftover object of that name in an
+  # interactive session (or restored from a .RData) made the first iteration
+  # take the merge branch against an unrelated data frame, so every burden
+  # column landed as NA while PROBES_COUNT (assigned unconditionally below)
+  # stayed populated — exactly the reported symptom.
+  temp_result <- NULL
+
   for ( k in seq_len(nrow(keys)))
   {
     # k <- 1
@@ -36,20 +46,47 @@ sem_study_summary_total <- function()
     colnames(pivot) <- combined_key
     pivot$Sample_ID <- row.names(pivot)
 
-    if(!exists("temp_result"))
+    if(is.null(temp_result))
       temp_result <- pivot
     else
     {
-      temp_result <- temp_result[, !(colnames(temp_result) == combined_key)]
+      temp_result <- temp_result[, !(colnames(temp_result) == combined_key), drop = FALSE]
       temp_result <- merge(temp_result, pivot, by="Sample_ID", all=TRUE)
     }
   }
-  if (!exists("temp_result"))
+  if (is.null(temp_result))
     return()
   temp_result[is.na(temp_result)] <- 0
   # remove from summary all column excet Sample_ID from temp_result
   col_temp <- colnames(temp_result)[!(colnames(temp_result) == "Sample_ID")]
   study_summary <- study_summary[, !(colnames(study_summary) %in% col_temp)]
+
+  # AI-083: the burden merge is name-based. If the two sides share no
+  # Sample_ID the all.x=TRUE merge silently yields a sample sheet whose burden
+  # columns are 100% NA (PROBES_COUNT below still gets filled), which then
+  # crashes every depth=1 inference downstream with "data are not the same
+  # size". Fail here, naming both sides, instead of writing that file.
+  ids_summary <- as.character(study_summary$Sample_ID)
+  ids_burden  <- as.character(temp_result$Sample_ID)
+  matched     <- intersect(ids_summary, ids_burden)
+  if (length(matched) == 0) {
+    core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " Burden aggregation matches no sample: sample sheet ids [",
+              paste(utils::head(ids_summary, 4), collapse = ", "),
+              "] vs pivot columns [",
+              paste(utils::head(ids_burden, 4), collapse = ", "), "].")
+    stop("sem_study_summary_total(): no Sample_ID in common between the sample ",
+         "sheet and the POSITION pivots — the burden columns would all be NA. ",
+         "Sample sheet ids: ", paste(utils::head(ids_summary, 4), collapse = ", "),
+         " | pivot columns: ", paste(utils::head(ids_burden, 4), collapse = ", "), ".")
+  }
+  missing_ids <- setdiff(unique(ids_summary), ids_burden)
+  if (length(missing_ids) > 0)
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " ", length(missing_ids), " sample(s) have no burden in the POSITION pivots: ",
+              paste(utils::head(missing_ids, 10), collapse = ", "),
+              if (length(missing_ids) > 10) ", ..." else "")
+
   study_summary <- merge(study_summary, temp_result, by="Sample_ID", all.x=TRUE)
   study_summary$PROBES_COUNT <- ssEnv$probes_count
   # io_file_path_build() uppercases via core_name_cleaning() — on-disk name is

--- a/R/util_exploratory_analysis.R
+++ b/R/util_exploratory_analysis.R
@@ -322,7 +322,15 @@ util_exploratory_analysis <- function(categorical_variables,numerical_variables,
   }
 
   signal_data <- io_source_data_get(signal_data, TRUE)
-  colnames(signal_data) <- core_name_cleaning(colnames(signal_data))
+  # AI-224: normalise BOTH sides. Cleaning only the signal columns and then
+  # comparing them with the raw sample sheet identifiers is what produced the
+  # empty intersections below (and an all-but-PROBE "cleaned" parquet) for
+  # identifiers such as "C3L-00001-06".
+  .normalized <- core_normalize_sample_ids(sample_sheet, signal_data,
+                                           sample_id_column = sample_id_column)
+  sample_sheet <- .normalized$sample_sheet
+  signal_data  <- .normalized$signal_data
+  rm(.normalized)
 
   # signal_data <- signal_data[1:1000,]
   gc()
@@ -370,7 +378,11 @@ util_exploratory_analysis <- function(categorical_variables,numerical_variables,
   rm(signal_data)
   gc()
   signal_data <- io_source_data_get(signal_data_original)
-  colnames(signal_data) <- core_name_cleaning(colnames(signal_data))
+  # AI-224: same normalisation as above — sample_sheet identifiers were already
+  # normalised, so only the freshly reloaded matrix needs it here.
+  signal_data <- core_normalize_sample_ids(sample_sheet = NULL,
+                                           signal_data = signal_data,
+                                           sample_id_column = sample_id_column)$signal_data
   # signal_data <- signal_data[1:1000,]
 
   # remove rows with too many missing values

--- a/README.Rmd
+++ b/README.Rmd
@@ -191,4 +191,7 @@ If you use semseeker in published work, please cite the package:
 citation("semseeker")
 ```
 
-A Zenodo DOI will be registered for each release tag.
+The package is archived on Zenodo under the concept DOI
+[10.5281/zenodo.5095417](https://doi.org/10.5281/zenodo.5095417), which always
+resolves to the latest archived version; every release tag also gets its own
+version DOI.

--- a/README.md
+++ b/README.md
@@ -208,5 +208,7 @@ If you use semseeker in published work, please cite the package:
 citation("semseeker")
 ```
 
-A Zenodo DOI will be registered for each release tag (see
-[documents/requirements.md](documents/requirements.md)).
+The package is archived on Zenodo under the concept DOI
+[10.5281/zenodo.5095417](https://doi.org/10.5281/zenodo.5095417), which always
+resolves to the latest archived version; every release tag also gets its own
+version DOI.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,5 +11,5 @@ bibentry(
   year    = format(Sys.Date(), "%Y"),
   note    = paste("R package version", utils::packageVersion("SEMseeker")),
   url     = "https://github.com/drake69/SEMseeker",
-  doi     = "10.18129/B9.bioc.SEMseeker"
+  doi     = "10.5281/zenodo.5095417"
 )

--- a/tests/testthat/test-0-anno-columns-coverage.R
+++ b/tests/testthat/test-0-anno-columns-coverage.R
@@ -1,0 +1,56 @@
+## Coverage for previously-untested annotation column-builders.
+## Both are pure: gene columns parse ";"-delimited manifest strings, and chr
+## columns look CpGs up in a cytoband table (injected here for determinism).
+##
+## Covered:
+##   .anno_gene_columns()   UCSC_RefGene_Group/Name -> GENE_<region> columns
+##   .anno_chr_columns()    CHR + START -> CHR_CYTOBAND via a cytoband table
+
+# ---------------------------------------------------------------------------
+# .anno_gene_columns
+# ---------------------------------------------------------------------------
+
+test_that(".anno_gene_columns splits gene region/name pairs into GENE_* columns", {
+  out <- SEMseeker:::.anno_gene_columns(
+    group_str = c("Body;TSS200", "TSS1500"),
+    name_str  = c("TP53;BRCA1",  "EGFR"))
+
+  expect_equal(out$GENE_BODY,    c("TP53", NA))
+  expect_equal(out$GENE_TSS200,  c("BRCA1", NA))
+  expect_equal(out$GENE_TSS1500, c(NA, "EGFR"))
+  # WHOLE is the union of all gene names on each probe
+  expect_equal(out$GENE_WHOLE,   c("TP53;BRCA1", "EGFR"))
+})
+
+test_that(".anno_gene_columns yields NA for probes with no gene annotation", {
+  out <- SEMseeker:::.anno_gene_columns(group_str = "", name_str = "")
+  expect_true(is.na(out$GENE_BODY))
+  expect_true(is.na(out$GENE_WHOLE))
+})
+
+# ---------------------------------------------------------------------------
+# .anno_chr_columns
+# ---------------------------------------------------------------------------
+
+test_that(".anno_chr_columns maps positions to cytobands and NA outside any band", {
+  cb <- data.frame(
+    CHR      = c("1", "1"),
+    START    = c(1L, 1000L),
+    END      = c(999L, 2000L),
+    CYTOBAND = c("p1", "p2"),
+    stringsAsFactors = FALSE)
+
+  res <- SEMseeker:::.anno_chr_columns(
+    chr      = c("1", "1", "1"),
+    start    = c(500L, 1500L, 3000L),   # in p1, in p2, past the last band
+    cytoband = cb)
+
+  expect_equal(res$CHR_CYTOBAND, c("p1", "p2", NA))
+})
+
+test_that(".anno_chr_columns returns NA for chromosomes absent from the table", {
+  cb <- data.frame(CHR = "1", START = 1L, END = 999L, CYTOBAND = "p1",
+                   stringsAsFactors = FALSE)
+  res <- SEMseeker:::.anno_chr_columns(chr = "7", start = 500L, cytoband = cb)
+  expect_true(is.na(res$CHR_CYTOBAND))
+})

--- a/tests/testthat/test-0-anno-core-internal-coverage.R
+++ b/tests/testthat/test-0-anno-core-internal-coverage.R
@@ -1,0 +1,118 @@
+## Coverage for previously-untested internal helpers (annotation + core).
+## All deterministic; GRanges-based helpers build tiny synthetic ranges.
+##
+## Covered:
+##   sem_metrics_name_collect()       currently a no-op (returns NULL)
+##   .anno_normalize_label_set()      ;-split, chr-strip, upper, sort-unique
+##   .anno_area_category()            AREA -> annotation backend switch
+##   .anno_islands_gr_from_names()    "chrN:start-end" strings -> GRanges
+##   .anno_opensea_gaps()             inter-island gaps as labelled GRanges
+##   .anno_assign_opensea_labels()    probes -> containing-gap label / NA
+##   .anno_island_columns()           Relation_to_Island -> ISLAND_* columns
+##   .core_pop_arg()                  pop a named arg with a default
+
+# ---------------------------------------------------------------------------
+# sem_metrics_name_collect  (no-op placeholder)
+# ---------------------------------------------------------------------------
+
+test_that("sem_metrics_name_collect is a no-op returning NULL", {
+  expect_null(SEMseeker:::sem_metrics_name_collect(data.frame(A = 1)))
+})
+
+# ---------------------------------------------------------------------------
+# .anno_normalize_label_set
+# ---------------------------------------------------------------------------
+
+test_that(".anno_normalize_label_set splits, strips chr, uppercases, dedups, sorts", {
+  expect_equal(SEMseeker:::.anno_normalize_label_set(character(0)), character(0))
+  expect_equal(
+    SEMseeker:::.anno_normalize_label_set(c("TP53;BRCA1", "chr1:100-200")),
+    c("1:100-200", "BRCA1", "TP53"))
+  # NA / empty dropped, case-insensitive de-duplication
+  expect_equal(SEMseeker:::.anno_normalize_label_set(c(NA, "", "tp53", "TP53")), "TP53")
+})
+
+# ---------------------------------------------------------------------------
+# .anno_area_category
+# ---------------------------------------------------------------------------
+
+test_that(".anno_area_category maps AREA to its annotation backend", {
+  expect_equal(SEMseeker:::.anno_area_category("GENE_TSS200"),  "txdb")
+  expect_equal(SEMseeker:::.anno_area_category("ISLAND_WHOLE"), "annotationhub")
+  expect_equal(SEMseeker:::.anno_area_category("CHR_CYTOBAND"), "bundled")
+  expect_equal(SEMseeker:::.anno_area_category("DMR_X"),        "bundled")
+  expect_equal(SEMseeker:::.anno_area_category("FOO_BAR"),      "unknown")
+})
+
+# ---------------------------------------------------------------------------
+# .anno_islands_gr_from_names
+# ---------------------------------------------------------------------------
+
+test_that(".anno_islands_gr_from_names parses coordinate strings into a GRanges", {
+  gr <- SEMseeker:::.anno_islands_gr_from_names(
+    c("chr1:100-200", "chrX:5-9", "garbage", NA))
+  expect_s4_class(gr, "GRanges")
+  expect_length(gr, 2L)
+  expect_equal(as.character(GenomicRanges::seqnames(gr)), c("chr1", "chrX"))
+  expect_equal(GenomicRanges::start(gr), c(100L, 5L))
+  expect_equal(GenomicRanges::end(gr),   c(200L, 9L))
+
+  expect_length(SEMseeker:::.anno_islands_gr_from_names(character(0)), 0L)
+  expect_length(SEMseeker:::.anno_islands_gr_from_names(c("nope", "x")), 0L)
+})
+
+# ---------------------------------------------------------------------------
+# .anno_opensea_gaps  /  .anno_assign_opensea_labels
+# ---------------------------------------------------------------------------
+
+test_that(".anno_opensea_gaps returns labelled inter-island gap ranges", {
+  islands <- GenomicRanges::GRanges(
+    "chr1", IRanges::IRanges(start = c(1000L, 50000L), end = c(2000L, 51000L)))
+  gaps <- SEMseeker:::.anno_opensea_gaps(islands)
+  expect_s4_class(gaps, "GRanges")
+  expect_true("label" %in% names(GenomicRanges::mcols(gaps)))
+  expect_gte(length(gaps), 1L)   # at least the gap between the two islands
+})
+
+test_that(".anno_assign_opensea_labels labels open-sea probes and NA-s island probes", {
+  islands <- GenomicRanges::GRanges("chr1", IRanges::IRanges(1000L, 2000L))
+  out <- SEMseeker:::.anno_assign_opensea_labels(
+    probe_chr = c("chr1", "chr1"),
+    probe_pos = c(1500L, 30000L),   # inside island vs far away (open sea)
+    island_gr = islands)
+  expect_length(out, 2L)
+  expect_true(is.na(out[1]))        # inside the island neighbourhood
+  expect_false(is.na(out[2]))       # lands in an inter-island gap
+})
+
+# ---------------------------------------------------------------------------
+# .anno_island_columns
+# ---------------------------------------------------------------------------
+
+test_that(".anno_island_columns fans Relation_to_Island out into ISLAND_* columns", {
+  out <- SEMseeker:::.anno_island_columns(
+    island_rel  = c("Island", "N_Shore", "OpenSea"),
+    island_name = c("chr1:1000-2000", "chr1:1000-2000", "chr1:1000-2000"),
+    chr         = c("1", "1", "1"),
+    start       = c(1500L, 900L, 30000L))
+
+  expect_equal(out$ISLAND_ISLAND,  c("chr1:1000-2000", NA, NA))
+  expect_equal(out$ISLAND_N_SHORE, c(NA, "chr1:1000-2000", NA))
+  expect_true(is.na(out$ISLAND_WHOLE[3]))              # open sea excluded from WHOLE
+  expect_length(out$ISLAND_OPENSEA, 3L)
+  expect_false(is.na(out$ISLAND_OPENSEA[3]))           # open-sea probe gets a gap label
+})
+
+# ---------------------------------------------------------------------------
+# .core_pop_arg
+# ---------------------------------------------------------------------------
+
+test_that(".core_pop_arg pops a present arg and falls back to the default", {
+  present <- SEMseeker:::.core_pop_arg(list(a = 1, b = 2), "a", 99)
+  expect_equal(present$value, 1)
+  expect_false("a" %in% names(present$args))
+  expect_true("b" %in% names(present$args))
+
+  missing <- SEMseeker:::.core_pop_arg(list(b = 2), "z", 99)
+  expect_equal(missing$value, 99)
+})

--- a/tests/testthat/test-0-core-env-helpers-coverage.R
+++ b/tests/testthat/test-0-core-env-helpers-coverage.R
@@ -1,0 +1,64 @@
+## Coverage for previously-untested core session/env helpers.
+##
+## Covered:
+##   core_remove_empty_folders()      recursive prune of empty subdirectories
+##   .core_log_info()                 INFO logging wrapper (no-op w/o session)
+##   .core_init_env_check_kwargs()    explicit-args guard (pass-through)
+##   .core_apply_defaults()           apply a defaults spec onto the session
+##
+## Session test uses tempFolders index 43.
+
+# ---------------------------------------------------------------------------
+# core_remove_empty_folders
+# ---------------------------------------------------------------------------
+
+test_that("core_remove_empty_folders prunes empty dirs recursively but keeps non-empty ones", {
+  root <- tempfile("emptyprune")
+  dir.create(root)
+  on.exit(unlink(root, recursive = TRUE), add = TRUE)
+
+  dir.create(file.path(root, "empty1"))
+  dir.create(file.path(root, "nested"))
+  dir.create(file.path(root, "nested", "empty2"))
+  dir.create(file.path(root, "keep"))
+  writeLines("x", file.path(root, "keep", "f.txt"))
+
+  SEMseeker:::core_remove_empty_folders(root)
+
+  expect_false(dir.exists(file.path(root, "empty1")))
+  expect_false(dir.exists(file.path(root, "nested", "empty2")))
+  expect_false(dir.exists(file.path(root, "nested")))       # emptied after child removed
+  expect_true (dir.exists(file.path(root, "keep")))         # holds a file -> kept
+  expect_true (file.exists(file.path(root, "keep", "f.txt")))
+})
+
+# ---------------------------------------------------------------------------
+# .core_log_info  /  .core_init_env_check_kwargs
+# ---------------------------------------------------------------------------
+
+test_that(".core_log_info logs without error when no session is active", {
+  expect_no_error(SEMseeker:::.core_log_info("coverage smoke message"))
+})
+
+test_that(".core_init_env_check_kwargs passes explicit args through unchanged", {
+  expect_equal(SEMseeker:::.core_init_env_check_kwargs(list(a = 1, b = "x")),
+               list(a = 1, b = "x"))
+})
+
+# ---------------------------------------------------------------------------
+# .core_apply_defaults
+# ---------------------------------------------------------------------------
+
+test_that(".core_apply_defaults writes default values into the session", {
+  tf <- tempFolders[43]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  defaults <- list(cov_test_flag = list(value = TRUE))
+  args <- SEMseeker:::.core_apply_defaults(list(), defaults)
+
+  ssEnv <- SEMseeker:::core_get_session_info()
+  expect_true(isTRUE(ssEnv$cov_test_flag) || ssEnv$cov_test_flag == "TRUE")
+  # the consumed default is not left dangling in the returned argument list
+  expect_null(args[["cov_test_flag"]])
+})

--- a/tests/testthat/test-0-coverage-gate.R
+++ b/tests/testthat/test-0-coverage-gate.R
@@ -1,0 +1,98 @@
+## AI-074 — coverage is a mandatory pre-step of every SEM analysis.
+##
+## Three contracts, in decreasing order of importance:
+##   1. the coverage charts are produced on EVERY run, including the runs the
+##      gate rejects — they are the artefact the analyst reads;
+##   2. the run STOPS when the input barely overlaps the reference annotation,
+##      with a message naming the numbers;
+##   3. coverage_minimum lowers the bar explicitly for deliberate
+##      cross-technology runs.
+##
+## Session tests use tempFolders indices 10-12.
+
+.coverage_chart_files <- function(tf) {
+  list.files(file.path(tf, "Chart", "COVERAGE"), full.names = TRUE)
+}
+
+.coverage_sidecar <- function(tf) {
+  file.path(tf, "Data", "COVERAGE_GATE.json")
+}
+
+test_that("coverage gate passes and writes its sidecar when the input matches the annotation", {
+  tf <- tempFolders[10]
+  unlink(tf, recursive = TRUE)
+  SEMseeker:::core_init_env(result_folder = tf, tech = "K850",
+                            parallel_strategy = "sequential", start_fresh = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  # real EPIC probe ids from the bundled fixture
+  observed <- probe_features$PROBE[1:500]
+  metrics <- SEMseeker:::sem_coverage_gate(observed)
+
+  expect_equal(metrics$gate, "pass")
+  expect_equal(metrics$input_positions, length(unique(observed)))
+  expect_gte(metrics$coverage_percent, 80)
+  expect_equal(metrics$coverage_minimum, 80)
+
+  expect_true(file.exists(.coverage_sidecar(tf)))
+  back <- jsonlite::fromJSON(.coverage_sidecar(tf))
+  expect_equal(back$gate, "pass")
+})
+
+test_that("coverage gate stops the run below threshold AND still leaves the charts behind", {
+  tf <- tempFolders[11]
+  unlink(tf, recursive = TRUE)
+  SEMseeker:::core_init_env(result_folder = tf, tech = "K850",
+                            parallel_strategy = "sequential", start_fresh = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  # identifiers that exist in no manifest: 0% coverage
+  observed <- paste0("not_a_probe_", seq_len(300))
+
+  expect_error(SEMseeker:::sem_coverage_gate(observed), "Coverage gate failed")
+
+  # contract 1: charts are the artefact of the run, produced even when the
+  # gate rejects it — this is what the analyst opens to see WHAT was missing.
+  expect_gt(length(.coverage_chart_files(tf)), 0)
+
+  # the sidecar records the rejection for later audit
+  expect_true(file.exists(.coverage_sidecar(tf)))
+  back <- jsonlite::fromJSON(.coverage_sidecar(tf))
+  expect_equal(back$gate, "fail")
+  expect_equal(back$covered_positions, 0)
+})
+
+test_that("coverage_minimum lowers the bar explicitly for cross-technology runs", {
+  tf <- tempFolders[12]
+  unlink(tf, recursive = TRUE)
+  SEMseeker:::core_init_env(result_folder = tf, tech = "K850",
+                            parallel_strategy = "sequential", start_fresh = TRUE,
+                            coverage_minimum = 0)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  observed <- paste0("not_a_probe_", seq_len(300))
+  metrics <- SEMseeker:::sem_coverage_gate(observed)
+
+  expect_equal(metrics$gate, "pass")
+  expect_equal(metrics$coverage_minimum, 0)
+})
+
+test_that("coverage gate is not enforced on coordinate-based technologies", {
+  tf <- tempFolders[12]
+  unlink(tf, recursive = TRUE)
+  SEMseeker:::core_init_env(result_folder = tf, tech = "LONGREAD",
+                            genome_build = "hg38",
+                            parallel_strategy = "sequential", start_fresh = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  observed <- c("1:1000-1001", "1:2000-2001", "2:3000-3001")
+  metrics <- SEMseeker:::sem_coverage_gate(observed, tech = "LONGREAD")
+
+  expect_equal(metrics$gate, "skipped")
+  expect_equal(metrics$coverage_percent, 100)
+  expect_true(file.exists(.coverage_sidecar(tf)))
+})

--- a/tests/testthat/test-0-io-enrich-getters-coverage.R
+++ b/tests/testthat/test-0-io-enrich-getters-coverage.R
@@ -1,0 +1,89 @@
+## Coverage for pure, session-free IO/enrichment reader helpers.
+##
+## Covered:
+##   enrich_results_get()          read + filter a pathway result CSV
+##   io_source_data_get()          resolve a data.frame or a file path to a df
+##   util_finalize_job_results()   final per-job save (empty-results guard path)
+
+# ---------------------------------------------------------------------------
+# enrich_results_get
+# ---------------------------------------------------------------------------
+
+test_that("enrich_results_get returns an empty frame for a missing file", {
+  expect_equal(nrow(SEMseeker:::enrich_results_get(tempfile(fileext = ".csv"))), 0L)
+})
+
+test_that("enrich_results_get reads, significance-filters and top-N-truncates", {
+  csv <- tempfile(fileext = ".csv")
+  on.exit(unlink(csv), add = TRUE)
+  utils::write.csv2(
+    data.frame(PATHWAY = c("p1", "p2", "p3"), FDR = c(0.01, 0.20, 0.001)),
+    csv, row.names = FALSE)
+
+  expect_equal(nrow(SEMseeker:::enrich_results_get(csv)), 3L)
+
+  sig <- SEMseeker:::enrich_results_get(csv, significance_column = "FDR", alpha = 0.05)
+  expect_equal(nrow(sig), 2L)                       # 0.01 and 0.001 pass
+
+  top1 <- SEMseeker:::enrich_results_get(csv, significance_column = "FDR",
+                                         alpha = 0.05, top = 1)
+  expect_equal(nrow(top1), 1L)
+  expect_equal(top1$PATHWAY, "p3")                  # smallest FDR first
+
+  # required column missing -> empty
+  expect_equal(nrow(SEMseeker:::enrich_results_get(csv, required_columns = "MISSING")), 0L)
+})
+
+# ---------------------------------------------------------------------------
+# io_source_data_get
+# ---------------------------------------------------------------------------
+
+test_that("io_source_data_get returns a data.frame unchanged from an in-memory object", {
+  res <- SEMseeker:::io_source_data_get(data.frame(a = 1:3, b = 4:6))
+  expect_s3_class(res, "data.frame")
+  expect_equal(res$a, 1:3)
+})
+
+test_that("io_source_data_get returns NULL for a non-existent path", {
+  expect_message(
+    expect_null(SEMseeker:::io_source_data_get(file.path(tempdir(), "no_such_file.csv"))),
+    "not found")
+})
+
+test_that("io_source_data_get reads a CSV and promotes PROBE to rownames", {
+  csv <- tempfile(fileext = ".csv")
+  on.exit(unlink(csv), add = TRUE)
+  utils::write.csv2(
+    data.frame(PROBE = c("cg1", "cg2"), S1 = c(0.1, 0.2), S2 = c(0.3, 0.4)),
+    csv, row.names = FALSE)
+
+  res <- SEMseeker:::io_source_data_get(csv)
+  expect_s3_class(res, "data.frame")
+  expect_equal(rownames(res), c("cg1", "cg2"))
+  expect_false("PROBE" %in% colnames(res))
+})
+
+test_that("io_source_data_get with check_is_numeric stops on non-numeric columns", {
+  csv <- tempfile(fileext = ".csv")
+  on.exit(unlink(csv), add = TRUE)
+  utils::write.csv2(
+    data.frame(PROBE = c("cg1", "cg2"), LABEL = c("x", "y")),
+    csv, row.names = FALSE)
+
+  expect_error(SEMseeker:::io_source_data_get(csv, check_is_numeric = TRUE))
+})
+
+# ---------------------------------------------------------------------------
+# util_finalize_job_results  (empty-results guard path)
+# ---------------------------------------------------------------------------
+
+test_that("util_finalize_job_results is a no-op (NULL) when there are no results", {
+  expect_null(SEMseeker:::util_finalize_job_results(
+    results         = data.frame(),
+    inference_detail = list(transformation_x = ""),
+    family_test     = "gaussian",
+    filter_p_value  = FALSE,
+    fileNameResults = tempfile(fileext = ".csv"),
+    start_time      = Sys.time(),
+    processed_items = 0L))
+})

--- a/tests/testthat/test-0-io-helpers-coverage.R
+++ b/tests/testthat/test-0-io-helpers-coverage.R
@@ -1,0 +1,106 @@
+## Coverage for previously-untested IO / PIVOT helpers.
+##
+## Covered:
+##   io_guess_decimal_separator()   comma-vs-period heuristic on first 5 lines
+##   .io_find_coord_cols()          CHR/START/END column detection + aliases
+##   .io_make_probe_id()            synthetic "{CHR}_{START}" probe id
+##   io_inference_file_name()       inference-result path assembly (session)
+##   io_save_latex_table()          data.frame -> .tex via xtable
+##
+## Session test uses tempFolders index 42.
+
+# ---------------------------------------------------------------------------
+# io_guess_decimal_separator
+# ---------------------------------------------------------------------------
+
+test_that("io_guess_decimal_separator picks the majority separator", {
+  f_comma  <- tempfile(fileext = ".csv")
+  f_period <- tempfile(fileext = ".csv")
+  on.exit(unlink(c(f_comma, f_period)), add = TRUE)
+  writeLines(c("1,5", "2,3", "4,1"), f_comma)
+  writeLines(c("1.5", "2.3", "4.1"), f_period)
+
+  expect_equal(SEMseeker:::io_guess_decimal_separator(f_comma),  ",")
+  expect_equal(SEMseeker:::io_guess_decimal_separator(f_period), ".")
+})
+
+# ---------------------------------------------------------------------------
+# .io_find_coord_cols
+# ---------------------------------------------------------------------------
+
+test_that(".io_find_coord_cols detects coordinate columns and aliases", {
+  d1 <- data.frame(CHR = "chr1", START = 100L, s1 = 0.5)
+  expect_equal(SEMseeker:::.io_find_coord_cols(d1),
+               list(chr = "CHR", start = "START", end = NA_character_))
+
+  d2 <- data.frame(CHR = "chr1", START = 100L, END = 101L, s1 = 0.5)
+  expect_equal(SEMseeker:::.io_find_coord_cols(d2)$end, "END")
+
+  d3 <- data.frame(seqnames = "chr1", pos = 100L, s1 = 0.5)  # bedmethyl-style aliases
+  cols <- SEMseeker:::.io_find_coord_cols(d3)
+  expect_equal(cols$chr,   "seqnames")
+  expect_equal(cols$start, "pos")
+
+  d_none <- data.frame(s1 = 0.5, s2 = 0.3)
+  expect_null(SEMseeker:::.io_find_coord_cols(d_none))
+})
+
+# ---------------------------------------------------------------------------
+# .io_make_probe_id
+# ---------------------------------------------------------------------------
+
+test_that(".io_make_probe_id strips the chr prefix and joins with START", {
+  expect_equal(
+    SEMseeker:::.io_make_probe_id(c("chr1", "chrX"), c(10000L, 543200L)),
+    c("1_10000", "X_543200"))
+})
+
+# ---------------------------------------------------------------------------
+# io_inference_file_name
+# ---------------------------------------------------------------------------
+
+test_that("io_inference_file_name assembles a DEPTH/marker path", {
+  tf <- tempFolders[42]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  detail <- list(
+    covariates            = "",
+    covariates_dummy      = "",
+    covariates_pca        = FALSE,
+    family_test           = "gaussian",
+    transformation_y      = "",
+    independent_variable  = "AGE",
+    transformation_x      = "",
+    depth_analysis        = "3",
+    samples_sql_condition = NULL
+  )
+
+  path <- SEMseeker:::io_inference_file_name(detail, marker = "MUTATIONS",
+                                             folder = tf, file_extension = "csv")
+
+  expect_type(path, "character")
+  expect_length(path, 1L)
+  expect_match(path, "DEPTH", ignore.case = TRUE)
+  expect_match(path, "MUTATIONS", ignore.case = TRUE)
+  expect_match(path, "\\.csv$", ignore.case = TRUE)
+})
+
+# ---------------------------------------------------------------------------
+# io_save_latex_table
+# ---------------------------------------------------------------------------
+
+test_that("io_save_latex_table writes a .tex table with the caption", {
+  skip_if_not_installed("xtable")
+  csv <- tempfile(fileext = ".csv")
+  tex <- sub("\\.csv$", ".tex", csv)
+  on.exit(unlink(c(csv, tex)), add = TRUE)
+
+  df <- data.frame(GENE_NAME = c("TP53", "BRCA1"), P_VALUE = c("0.01", "0.20"))
+  SEMseeker:::io_save_latex_table(df, csv, caption = "My caption")
+
+  expect_true(file.exists(tex))
+  contents <- paste(readLines(tex), collapse = "\n")
+  expect_match(contents, "\\\\begin\\{table\\}")
+  expect_match(contents, "My caption")
+})

--- a/tests/testthat/test-0-plot-helpers-coverage.R
+++ b/tests/testthat/test-0-plot-helpers-coverage.R
@@ -1,0 +1,57 @@
+## Coverage for pure helpers behind the plotting layer.
+## The plot RENDERERS themselves read pipeline pivots / inference files (or,
+## for sem_manhattan_plot_marker_per_sample, reference ssEnv before it is
+## assigned), so they need full-pipeline fixtures / a source fix and are not
+## exercised here. These two internal helpers are pure and deterministic.
+##
+## Covered:
+##   .assoc_volcano_pick_estimate_col()  choose the estimate column to plot
+##   .plot_comparison_pvalue_label()     format a group-comparison p-value label
+
+# ---------------------------------------------------------------------------
+# .assoc_volcano_pick_estimate_col
+# ---------------------------------------------------------------------------
+
+test_that(".assoc_volcano_pick_estimate_col returns NULL when there is no usable estimate", {
+  expect_null(SEMseeker:::.assoc_volcano_pick_estimate_col(data.frame(X = 1, Y = 2)))
+  # intercept estimates are excluded
+  expect_null(SEMseeker:::.assoc_volcano_pick_estimate_col(
+    data.frame(INTERCEPT_ESTIMATE = 1)))
+})
+
+test_that(".assoc_volcano_pick_estimate_col falls back to the first estimate w/o PVALUE", {
+  expect_equal(
+    SEMseeker:::.assoc_volcano_pick_estimate_col(data.frame(AGE_ESTIMATE = 0.5)),
+    "AGE_ESTIMATE")
+})
+
+test_that(".assoc_volcano_pick_estimate_col matches the estimate whose PVALUE equals PVALUE", {
+  df <- data.frame(
+    AGE_ESTIMATE = 0.5, AGE_PVALUE = 0.01,
+    BMI_ESTIMATE = 0.2, BMI_PVALUE = 0.40,
+    PVALUE       = 0.01)
+  expect_equal(SEMseeker:::.assoc_volcano_pick_estimate_col(df), "AGE_ESTIMATE")
+})
+
+# ---------------------------------------------------------------------------
+# .plot_comparison_pvalue_label
+# ---------------------------------------------------------------------------
+
+test_that(".plot_comparison_pvalue_label formats a p-value for supported tests", {
+  set.seed(1)
+  df <- data.frame(
+    VALUE = c(stats::rnorm(10, 0), stats::rnorm(10, 4)),
+    GRP   = rep(c("a", "b"), each = 10))
+
+  expect_match(
+    SEMseeker:::.plot_comparison_pvalue_label(df, "GRP", "VALUE", "t.test"),
+    "^p = ")
+  expect_match(
+    SEMseeker:::.plot_comparison_pvalue_label(df, "GRP", "VALUE", "kruskal.test"),
+    "^p = ")
+})
+
+test_that(".plot_comparison_pvalue_label returns NA for an unsupported family", {
+  df <- data.frame(VALUE = c(1, 2, 3, 4), GRP = c("a", "a", "b", "b"))
+  expect_true(is.na(SEMseeker:::.plot_comparison_pvalue_label(df, "GRP", "VALUE", "nope")))
+})

--- a/tests/testthat/test-0-pure-helpers-coverage.R
+++ b/tests/testthat/test-0-pure-helpers-coverage.R
@@ -1,0 +1,161 @@
+# Coverage for previously-untested PURE / UTILITY helpers (no session needed).
+#
+# These are deterministic, dependency-free functions (label formatting, order
+# checks, gene-set set-algebra, string wrapping, BLAS introspection). Assertions
+# are exact where the output is fully determined; the annotation-package helpers
+# skip_if_not_installed() because they read Bioconductor Suggests data.
+#
+# Covered:
+#   util_pretty_label()                     underscore->space display labels
+#   util_test_match_order()                 same-order equality of two vectors
+#   util_test_match_order_by_rownames()     same-rowname-order of two frames
+#   enrich_find_unique_gene_sets()          per-group unique set-difference
+#   enrich_wrap_it()                        fixed-width string wrapping
+#   .core_blas_info()                       BLAS flavour introspection
+#   .core_warn_blas_single_thread()         one-shot BLAS warning (no-op log)
+#   .anno_detect_tech_from_anno()           array detection by probe overlap
+#   .anno_pkg_load_table/_probe_ids/_to_df  Illumina anno-package readers
+
+# ---------------------------------------------------------------------------
+# util_pretty_label
+# ---------------------------------------------------------------------------
+
+test_that("util_pretty_label turns UPPER_SNAKE into spaced labels", {
+  expect_equal(SEMseeker:::util_pretty_label("TUMOUR_STAGE_N"),   "TUMOUR STAGE N")
+  expect_equal(SEMseeker:::util_pretty_label("PVALUE_ADJ_ALL_FDR"), "PVALUE ADJ ALL FDR")
+})
+
+test_that("util_pretty_label collapses repeated separators and trims", {
+  expect_equal(SEMseeker:::util_pretty_label("A__B"), "A B")     # double underscore
+  expect_equal(SEMseeker:::util_pretty_label("_A_"),  "A")       # leading/trailing
+})
+
+test_that("util_pretty_label passes NA and empty through, preserves length", {
+  expect_equal(SEMseeker:::util_pretty_label(c("DELTARP_GENE_TSS200", NA, "")),
+               c("DELTARP GENE TSS200", NA, ""))
+  expect_equal(SEMseeker:::util_pretty_label(character(0)), character(0))
+})
+
+# ---------------------------------------------------------------------------
+# util_test_match_order / util_test_match_order_by_rownames
+# ---------------------------------------------------------------------------
+
+test_that("util_test_match_order is TRUE only for identical same-order vectors", {
+  expect_true (SEMseeker:::util_test_match_order(c(1, 2, 3), c(1, 2, 3)))
+  expect_true (SEMseeker:::util_test_match_order(c("a", "b"), c("a", "b")))
+  expect_false(SEMseeker:::util_test_match_order(c(1, 2, 3), c(3, 2, 1)))  # same set, wrong order
+  expect_false(SEMseeker:::util_test_match_order(c(1, 2, 3), c(4, 5, 6)))  # disjoint
+})
+
+test_that("util_test_match_order returns FALSE on NULL input", {
+  expect_false(SEMseeker:::util_test_match_order(NULL, c(1, 2, 3)))
+  expect_false(SEMseeker:::util_test_match_order(c(1, 2, 3), NULL))
+})
+
+test_that("util_test_match_order_by_rownames compares rowname order", {
+  a <- data.frame(v = 1:3, row.names = c("p1", "p2", "p3"))
+  b <- data.frame(v = 4:6, row.names = c("p1", "p2", "p3"))
+  c <- data.frame(v = 7:9, row.names = c("p3", "p2", "p1"))
+  expect_true (SEMseeker:::util_test_match_order_by_rownames(a, b))
+  expect_false(SEMseeker:::util_test_match_order_by_rownames(a, c))
+  expect_false(SEMseeker:::util_test_match_order_by_rownames(NULL, a))
+})
+
+# ---------------------------------------------------------------------------
+# enrich_find_unique_gene_sets
+# ---------------------------------------------------------------------------
+
+test_that("enrich_find_unique_gene_sets keeps only per-group unique members", {
+  res <- SEMseeker:::enrich_find_unique_gene_sets(
+    list(A = c("g1", "g2", "g3"), B = c("g3", "g4"), C = c("g5")))
+  expect_equal(sort(res$A), c("g1", "g2"))
+  expect_equal(res$B, "g4")
+  expect_equal(res$C, "g5")
+})
+
+test_that("enrich_find_unique_gene_sets drops groups with no unique members", {
+  res <- SEMseeker:::enrich_find_unique_gene_sets(
+    list(A = c("g1"), B = c("g1")))
+  expect_length(res, 0)
+})
+
+# ---------------------------------------------------------------------------
+# enrich_wrap_it
+# ---------------------------------------------------------------------------
+
+test_that("enrich_wrap_it wraps long strings and leaves short ones intact", {
+  expect_equal(SEMseeker:::enrich_wrap_it("hello", 20), "hello")           # fits
+  wrapped <- SEMseeker:::enrich_wrap_it("aaaa bbbb cccc dddd", 9)
+  expect_match(wrapped, "\n")                                              # broke into lines
+  expect_equal(length(SEMseeker:::enrich_wrap_it(c("a", "b"), 5)), 2L)     # length preserved
+  expect_null(names(SEMseeker:::enrich_wrap_it(c("a", "b"), 5)))           # USE.NAMES = FALSE
+})
+
+# ---------------------------------------------------------------------------
+# .core_blas_info / .core_warn_blas_single_thread
+# ---------------------------------------------------------------------------
+
+test_that(".core_blas_info returns a coherent BLAS descriptor", {
+  info <- SEMseeker:::.core_blas_info()
+  expect_named(info, c("path", "multi_threaded", "flavor", "is_reference"),
+               ignore.order = TRUE)
+  expect_type(info$multi_threaded, "logical")
+  expect_type(info$is_reference,   "logical")
+  expect_true(info$flavor %in% c("Accelerate (vecLib)", "OpenBLAS", "MKL",
+                                 "reference (single-thread)", "unknown"))
+  # a reference BLAS is single-threaded by definition
+  if (isTRUE(info$is_reference)) {
+    expect_equal(info$flavor, "reference (single-thread)")
+    expect_false(info$multi_threaded)
+  }
+})
+
+test_that(".core_warn_blas_single_thread returns the BLAS info invisibly", {
+  # core_log_event() no-ops without an initialised session, so this is safe.
+  expect_no_error(res <- SEMseeker:::.core_warn_blas_single_thread())
+  expect_equal(res$flavor, SEMseeker:::.core_blas_info()$flavor)
+})
+
+# ---------------------------------------------------------------------------
+# .anno_detect_tech_from_anno  (deterministic no-overlap path)
+# ---------------------------------------------------------------------------
+
+test_that(".anno_detect_tech_from_anno returns '' when nothing overlaps", {
+  # No real probe id matches -> every array count is 0 (or no anno pkg) -> "".
+  expect_identical(SEMseeker:::.anno_detect_tech_from_anno("ZZZ_not_a_probe"), "")
+  expect_identical(SEMseeker:::.anno_detect_tech_from_anno(character(0)),      "")
+})
+
+# ---------------------------------------------------------------------------
+# .anno_pkg_* readers  (require an Illumina annotation Suggests package)
+# ---------------------------------------------------------------------------
+
+test_that(".anno_pkg_probe_ids / .anno_pkg_load_table expose Illumina probe ids", {
+  pkg <- "IlluminaHumanMethylation27kanno.ilmn12.hg19"   # smallest array
+  skip_if_not_installed(pkg)
+
+  ids <- SEMseeker:::.anno_pkg_probe_ids(pkg)
+  expect_type(ids, "character")
+  expect_gt(length(ids), 0L)
+  expect_true(any(grepl("^cg", ids)))
+
+  locs <- SEMseeker:::.anno_pkg_load_table(pkg, "Locations")
+  expect_s3_class(locs, "data.frame")
+  expect_true("chr" %in% colnames(locs))
+  expect_setequal(rownames(locs), ids)
+})
+
+test_that(".anno_pkg_to_df combines Locations + Islands + Other for one probe/row", {
+  # Needs an array that ships the Islands.UCSC sub-table (450k / EPIC; the 27k
+  # array lacks it and the current fallback in .anno_pkg_to_df cannot rebuild a
+  # matching-length frame -- tracked separately, not exercised here).
+  pkg <- "IlluminaHumanMethylation450kanno.ilmn12.hg19"
+  skip_if_not_installed(pkg)
+
+  df  <- SEMseeker:::.anno_pkg_to_df(pkg)
+  ids <- SEMseeker:::.anno_pkg_probe_ids(pkg)
+  expect_s3_class(df, "data.frame")
+  expect_gt(nrow(df), 0L)
+  expect_true(all(c("chr", "Relation_to_Island") %in% colnames(df)))
+  expect_setequal(rownames(df), ids)
+})

--- a/tests/testthat/test-0-sample_id_normalization.R
+++ b/tests/testthat/test-0-sample_id_normalization.R
@@ -1,0 +1,141 @@
+## AI-224 — sample identifier normalisation must be forced on BOTH sides
+## (sample sheet + signal matrix) before any name-based column subsetting.
+##
+## Regression: SEMseeker cleaned `colnames(signal_data)` with
+## core_name_cleaning() but compared/subset them with the RAW `Sample_ID`
+## values. With identifiers such as "C3L-00001-06" (-> "C3L_00001_06") the
+## intersection is empty: util_exploratory_analysis() wrote a "cleaned" parquet
+## containing only the PROBE column, and the SEM path failed downstream with
+## "undefined columns selected". Invisible on the bundled fixtures because
+## GSM\d+ identifiers make core_name_cleaning() a no-op.
+##
+## Session test uses tempFolders index 9.
+
+# ---------------------------------------------------------------------------
+# core_normalize_sample_ids  (pure)
+# ---------------------------------------------------------------------------
+
+test_that("core_normalize_sample_ids normalises sheet and signal columns coherently", {
+  ss  <- data.frame(Sample_ID = c("C3L-00001-06", "C3L-00002-06"),
+                    Sample_Group = c("Case", "Reference"),
+                    stringsAsFactors = FALSE)
+  sig <- data.frame(`C3L-00001-06` = c(0.1, 0.2), `C3L-00002-06` = c(0.3, 0.4),
+                    check.names = FALSE)
+
+  out <- SEMseeker:::core_normalize_sample_ids(ss, sig)
+
+  expect_equal(out$sample_sheet$Sample_ID, c("C3L_00001_06", "C3L_00002_06"))
+  expect_equal(colnames(out$signal_data), c("C3L_00001_06", "C3L_00002_06"))
+  # the whole point: the two sides match after normalisation
+  expect_true(all(out$sample_sheet$Sample_ID %in% colnames(out$signal_data)))
+  expect_length(out$unmatched_ids, 0)
+  expect_length(out$unmatched_columns, 0)
+})
+
+test_that("core_normalize_sample_ids is idempotent", {
+  ss  <- data.frame(Sample_ID = c("C3L-00001-06", "GSM123456"),
+                    stringsAsFactors = FALSE)
+  sig <- data.frame(`C3L-00001-06` = 1, `GSM123456` = 2, check.names = FALSE)
+
+  once  <- SEMseeker:::core_normalize_sample_ids(ss, sig)
+  twice <- SEMseeker:::core_normalize_sample_ids(once$sample_sheet, once$signal_data)
+
+  expect_equal(twice$sample_sheet$Sample_ID, once$sample_sheet$Sample_ID)
+  expect_equal(colnames(twice$signal_data), colnames(once$signal_data))
+  # GSM identifiers are untouched — this is why the bug stayed hidden
+  expect_true("GSM123456" %in% once$sample_sheet$Sample_ID)
+})
+
+test_that("core_normalize_sample_ids leaves structural columns untouched", {
+  sig <- data.frame(PROBE = "cg0001", CHR = "chr1", START = 1, END = 2,
+                    `C3L-00001-06` = 0.5, check.names = FALSE)
+
+  out <- SEMseeker:::core_normalize_sample_ids(NULL, sig)
+
+  expect_equal(colnames(out$signal_data),
+               c("PROBE", "CHR", "START", "END", "C3L_00001_06"))
+})
+
+test_that("core_normalize_sample_ids fails when normalisation collapses distinct ids", {
+  ss <- data.frame(Sample_ID = c("S-1", "S.1"), stringsAsFactors = FALSE)
+
+  expect_error(SEMseeker:::core_normalize_sample_ids(ss),
+               "collapses distinct")
+})
+
+test_that("core_normalize_sample_ids reports orphan identifiers instead of 'undefined columns selected'", {
+  ss  <- data.frame(Sample_ID = c("C3L-00001-06", "C3L-00099-06"),
+                    stringsAsFactors = FALSE)
+  sig <- data.frame(`C3L-00001-06` = c(0.1, 0.2), check.names = FALSE)
+
+  expect_error(
+    SEMseeker:::core_normalize_sample_ids(ss, sig, require_all_ids = TRUE),
+    "C3L_00099_06"
+  )
+  # non-strict mode reports them without failing
+  quiet <- SEMseeker:::core_normalize_sample_ids(ss, sig)
+  expect_equal(quiet$unmatched_ids, "C3L_00099_06")
+})
+
+test_that("core_normalize_sample_ids fails loudly when the id column is missing", {
+  expect_error(
+    SEMseeker:::core_normalize_sample_ids(data.frame(ID = "a", stringsAsFactors = FALSE)),
+    "no 'Sample_ID' column"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# util_exploratory_analysis  (end-to-end regression on dashed identifiers)
+# ---------------------------------------------------------------------------
+
+test_that("util_exploratory_analysis keeps sample columns with non-alphanumeric Sample_IDs", {
+  tf <- tempFolders[9]
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  # CPTAC-style identifiers: core_name_cleaning() turns "-" into "_"
+  raw_ids <- paste0("C3L-", sprintf("%05d", seq_len(ncol(signal_data))), "-06")
+  dashed_signal <- signal_data
+  colnames(dashed_signal) <- raw_ids
+
+  dashed_sheet <- mySampleSheet
+  dashed_sheet$Sample_ID <- raw_ids[match(dashed_sheet$Sample_ID, colnames(signal_data))]
+  dashed_sheet <- dashed_sheet[!is.na(dashed_sheet$Sample_ID), ]
+
+  expected_ids <- unique(SEMseeker:::core_name_cleaning(dashed_sheet$Sample_ID))
+
+  expect_no_error(
+    SEMseeker:::util_exploratory_analysis(
+      categorical_variables = c("Sample_Group"),
+      numerical_variables   = c("Phenotest", "Covariates1"),
+      sample_sheet          = dashed_sheet,
+      signal_data           = dashed_signal,
+      result_folder         = tf,
+      parallel_strategy     = "sequential",
+      start_fresh           = TRUE,
+      showprogress          = FALSE,
+      verbosity             = 1
+    )
+  )
+
+  explo_dir <- file.path(tf, "Data", "Exploratory_0")
+  expect_true(dir.exists(explo_dir))
+
+  parquet_path <- list.files(explo_dir, pattern = "CLEANED_SIGNAL_DATA.*\\.parquet$",
+                             full.names = TRUE, ignore.case = TRUE)
+  expect_length(parquet_path, 1)
+
+  cleaned <- as.data.frame(polars::pl$read_parquet(parquet_path[1]))
+  sample_cols <- setdiff(colnames(cleaned), "PROBE")
+
+  # THE regression: before AI-224 this parquet held the PROBE column only
+  expect_gt(length(sample_cols), 0)
+  expect_true(all(expected_ids %in% sample_cols))
+
+  # ... and the cleaned sample sheet must address exactly those columns
+  sheet_path <- list.files(explo_dir, pattern = "CLEANED_SAMPLE_SHEET.*\\.csv$",
+                           full.names = TRUE, ignore.case = TRUE)
+  expect_length(sheet_path, 1)
+  cleaned_sheet <- utils::read.csv2(sheet_path[1], stringsAsFactors = FALSE)
+  expect_setequal(unique(as.character(cleaned_sheet$Sample_ID)), sample_cols)
+})

--- a/tests/testthat/test-1-glm-model-coverage.R
+++ b/tests/testthat/test-1-glm-model-coverage.R
@@ -1,0 +1,67 @@
+## Session-based coverage for assoc_glm_model() (previously untested).
+##
+## assoc_glm_model() fits stats::glm() for a given family and returns a
+## one-row data.frame of AIC/BIC, per-coefficient p-values and estimates,
+## model-performance metrics and (gaussian only) residual diagnostics.
+## Uses synthetic data — this exercises the statistical plumbing, not a
+## biological claim, so a controlled random design is appropriate.
+##
+## Uses tempFolders indices 40-41 to avoid collision with other test files.
+
+.glm_key <- function() {
+  list(AREA = "GENE", SUBAREA = "TSS200", MARKER = "MUTATIONS", FIGURE = "K850")
+}
+
+test_that("assoc_glm_model (gaussian) returns AIC/BIC, p-values and residual diagnostics", {
+  tf <- tempFolders[40]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  set.seed(1)
+  df  <- data.frame(x = stats::rnorm(40), y = stats::rnorm(40))
+
+  res <- SEMseeker:::assoc_glm_model(
+    family_test           = "gaussian",
+    tempDataFrame         = df,
+    sig.formula           = stats::as.formula("y ~ x"),
+    transformation_y      = "",
+    plot                  = FALSE,
+    samples_sql_condition = "",
+    key                   = .glm_key()
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 1L)
+  expect_true(all(c("AIC_VALUE", "BIC_VALUE") %in% colnames(res)))
+  expect_type(res$AIC_VALUE, "double")
+  expect_true(any(grepl("PVALUE",  colnames(res))))    # per-coefficient p-values
+  expect_true(any(grepl("ESTIMATE", colnames(res))))
+  expect_true("residuals_normality" %in% colnames(res))
+  expect_equal(res$r_model, "stats::glm")
+})
+
+test_that("assoc_glm_model (binomial) fits a logistic model and reports AIC", {
+  tf <- tempFolders[41]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  set.seed(2)
+  n  <- 40L
+  x  <- stats::rnorm(n)
+  df <- data.frame(x = x, y = stats::rbinom(n, 1, stats::plogis(x)))
+
+  res <- SEMseeker:::assoc_glm_model(
+    family_test           = "binomial",
+    tempDataFrame         = df,
+    sig.formula           = stats::as.formula("y ~ x"),
+    transformation_y      = "",
+    plot                  = FALSE,
+    samples_sql_condition = "",
+    key                   = .glm_key()
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_true("AIC_VALUE" %in% colnames(res))
+  expect_true(any(grepl("PVALUE", colnames(res))))
+  expect_equal(res$r_model, "stats::glm")
+})

--- a/tests/testthat/test-1-highroi-coverage.R
+++ b/tests/testthat/test-1-highroi-coverage.R
@@ -1,0 +1,121 @@
+## High-line-ROI coverage for previously 0%-covered files.
+##
+## Covered:
+##   .core_bulk_model_memory_gate()   pure memory-budget decision (no deps)
+##   io_plot_file_name()              plot-path assembly (session)
+##   assoc_results_save()             write inference CSV to canonical path
+##   util_exploratory_analysis()      end-to-end exploratory report (215 lines)
+##
+## Session tests use tempFolders indices 51-53.
+
+# ---------------------------------------------------------------------------
+# .core_bulk_model_memory_gate  (pure)
+# ---------------------------------------------------------------------------
+
+test_that(".core_bulk_model_memory_gate returns a coherent decision + breakdown", {
+  g <- SEMseeker:::.core_bulk_model_memory_gate(n_probes = 1000, n_samples = 10, n_coef = 2)
+
+  expect_type(g, "list")
+  expect_true(all(c("decision", "y_mat_GB", "lmfit_GB", "mono_peak_GB",
+                    "chunk_y_GB", "chunk_peak_GB", "fit_object_GB",
+                    "total_RAM_GB", "mem_frac", "available_GB") %in% names(g)))
+  expect_true(g$decision %in% c("monolithic", "chunked", "abort"))
+  # exact numeric identities
+  expect_equal(g$y_mat_GB, 1000 * 10 * 8 / 1024^3)
+  expect_equal(g$lmfit_GB, 1.5 * g$y_mat_GB)
+  expect_equal(g$mono_peak_GB, g$y_mat_GB + g$lmfit_GB)
+  expect_true(g$mem_frac > 0 && g$mem_frac <= 1)
+  # a tiny matrix always fits (or falls back to monolithic when RAM unknown)
+  expect_equal(g$decision, "monolithic")
+})
+
+test_that(".core_bulk_model_memory_gate escalates away from monolithic when huge", {
+  h <- SEMseeker:::.core_bulk_model_memory_gate(n_probes = 1e8, n_samples = 1000, n_coef = 2)
+  # only assert the escalation when system RAM was actually detected
+  if (!is.na(h$total_RAM_GB))
+    expect_true(h$decision %in% c("chunked", "abort"))
+  expect_gt(h$mono_peak_GB, h$chunk_peak_GB)   # monolithic peak > single-chunk peak
+})
+
+# ---------------------------------------------------------------------------
+# io_plot_file_name  (session)
+# ---------------------------------------------------------------------------
+
+test_that("io_plot_file_name builds a DEPTH/marker/figure plot path", {
+  tf <- tempFolders[51]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  detail <- list(
+    family_test          = "gaussian",
+    transformation_y     = "",
+    independent_variable = "AGE",
+    depth_analysis       = "3",
+    samples_sql_condition = NULL
+  )
+  key <- list(AREA = "GENE", SUBAREA = "TSS200", MARKER = "MUTATIONS", FIGURE = "HYPER")
+
+  path <- SEMseeker:::io_plot_file_name(detail, folder = tf, key = key)
+
+  expect_type(path, "character")
+  expect_match(path, "DEPTH", ignore.case = TRUE)
+  expect_match(path, "MUTATIONS", ignore.case = TRUE)
+  expect_match(path, "\\.png$", ignore.case = TRUE)
+})
+
+# ---------------------------------------------------------------------------
+# assoc_results_save  (session, writes CSV)
+# ---------------------------------------------------------------------------
+
+test_that("assoc_results_save writes a readable inference CSV at the canonical path", {
+  tf <- tempFolders[52]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  detail <- list(
+    covariates            = "",
+    covariates_dummy      = "",
+    covariates_pca        = FALSE,
+    family_test           = "gaussian",
+    transformation_y      = "",
+    independent_variable  = "AGE",
+    transformation_x      = "",
+    depth_analysis        = "3",
+    samples_sql_condition = NULL
+  )
+  df <- data.frame(AREA = "GENE", SUBAREA = "TSS200", VALUE = 0.42)
+
+  path <- SEMseeker:::assoc_results_save(df, detail, marker = "MUTATIONS")
+
+  expect_type(path, "character")
+  expect_true(file.exists(path))
+  back <- utils::read.csv2(path, stringsAsFactors = FALSE)
+  expect_equal(nrow(back), 1L)
+  expect_true("AREA" %in% colnames(back))
+})
+
+# ---------------------------------------------------------------------------
+# util_exploratory_analysis  (end-to-end on the bundled GEO fixture)
+# ---------------------------------------------------------------------------
+
+test_that("util_exploratory_analysis runs end-to-end and writes an exploratory report", {
+  tf <- tempFolders[53]
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE); unlink(tf, recursive = TRUE) },
+          add = TRUE)
+
+  expect_no_error(
+    SEMseeker:::util_exploratory_analysis(
+      categorical_variables = c("Sample_Group"),
+      numerical_variables   = c("Phenotest", "Covariates1"),
+      sample_sheet          = mySampleSheet,
+      signal_data           = signal_data,
+      result_folder         = tf,
+      parallel_strategy     = "sequential",
+      start_fresh           = TRUE,
+      showprogress          = FALSE,
+      verbosity             = 1
+    )
+  )
+
+  expect_true(dir.exists(file.path(tf, "Data", "Exploratory_0")))
+})

--- a/tests/testthat/test-1-io-bed-lister-coverage.R
+++ b/tests/testthat/test-1-io-bed-lister-coverage.R
@@ -1,0 +1,33 @@
+## Coverage for io_list_bed_files_for_marker_figure() (previously untested).
+##
+## Lists per-sample BED/bedGraph files under
+##   <result_folderData>/<sample_group>/<MARKER>_<FIGURE>/...
+## for a given marker+figure. Session test uses tempFolders index 47.
+
+test_that("io_list_bed_files_for_marker_figure finds only matching marker/figure beds", {
+  tf <- tempFolders[47]
+  ss <- SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  data_root <- ss$result_folderData
+
+  # matching: Case / MUTATIONS_HYPER
+  d_match <- file.path(data_root, "Case", "MUTATIONS_HYPER")
+  dir.create(d_match, recursive = TRUE, showWarnings = FALSE)
+  writeLines("chr1\t1\t2", file.path(d_match, "s1.bed"))
+
+  # non-matching marker/figure
+  d_other <- file.path(data_root, "Case", "DELTAS_HYPO")
+  dir.create(d_other, recursive = TRUE, showWarnings = FALSE)
+  writeLines("chr1\t1\t2", file.path(d_other, "s2.bed"))
+
+  hits <- SEMseeker:::io_list_bed_files_for_marker_figure("MUTATIONS", "HYPER")
+  expect_length(hits, 1L)
+  expect_match(hits, "MUTATIONS_HYPER")
+  expect_false(any(grepl("DELTAS_HYPO", hits)))
+
+  # a marker/figure with no files returns an empty character vector
+  expect_length(
+    SEMseeker:::io_list_bed_files_for_marker_figure("MUTATIONS", "BOTH"),
+    0L)
+})

--- a/tests/testthat/test-1-orchestrator-guards-coverage.R
+++ b/tests/testthat/test-1-orchestrator-guards-coverage.R
@@ -1,0 +1,73 @@
+## Coverage for association/enrichment ORCHESTRATORS via real sessions.
+##
+## The happy path of these functions requires full-pipeline artifacts
+## (pivots + inference CSVs) whose generation is (a) tied to parallel_strategy
+## in a way that is flaky under devtools::load_all and (b) affected by a known
+## depth=3 regression that empties results (see test-7). These tests therefore
+## exercise the deterministic ENTRY + guard/degenerate paths against a live
+## session: argument handling, inference-path construction, missing-file and
+## empty-input early returns. Full happy-path behaviour stays covered by the
+## end-to-end tests (test-6/7/8-*).
+##
+## Session tests use tempFolders indices 48-50.
+
+# ---------------------------------------------------------------------------
+# assoc_results_get — missing inference file -> empty data.frame
+# ---------------------------------------------------------------------------
+
+test_that("assoc_results_get returns an empty frame when the inference file is absent", {
+  tf <- tempFolders[48]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  detail <- list(
+    covariates            = "",
+    covariates_dummy      = "",
+    covariates_pca        = FALSE,
+    family_test           = "gaussian",
+    transformation_y      = "",
+    independent_variable  = "AGE",
+    transformation_x      = "",
+    depth_analysis        = "3",
+    samples_sql_condition = NULL,
+    areas_sql_condition   = ""
+  )
+
+  res <- SEMseeker:::assoc_results_get(inference_detail = detail, marker = "MUTATIONS")
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 0L)
+})
+
+# ---------------------------------------------------------------------------
+# assoc_data_extractor — no inference rows -> empty result
+# ---------------------------------------------------------------------------
+
+test_that("assoc_data_extractor returns an empty frame for zero inference rows", {
+  tf <- tempFolders[49]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  res <- SEMseeker:::assoc_data_extractor(
+    inference_details = data.frame(),
+    destination_folder = "",
+    result_folder = "")             # "" -> reuse the active session
+
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 0L)
+})
+
+# ---------------------------------------------------------------------------
+# sem_available_metrics — no inference rows -> NULL
+# ---------------------------------------------------------------------------
+
+test_that("sem_available_metrics is a no-op (NULL) when there are no inference rows", {
+  tf <- tempFolders[50]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  res <- SEMseeker:::sem_available_metrics(
+    inference_details = data.frame(),
+    result_folder     = tf)
+
+  expect_null(res)
+})

--- a/tests/testthat/test-1-session-metadata-coverage.R
+++ b/tests/testthat/test-1-session-metadata-coverage.R
@@ -1,0 +1,125 @@
+## Coverage for session-metadata provenance helpers and quantreg metrics.
+##
+## Covered:
+##   core_session_metadata_write()        session_metadata.json provenance
+##   core_pivot_sidecar_write()           per-pivot _meta.json sidecar
+##   core_check_session_compatibility()   cross-session build/tech enforcement
+##   assoc_quantreg_metrics()             pinball loss / QQ metrics (no plot)
+##
+## Session tests use tempFolders indices 44-46.
+
+# ---------------------------------------------------------------------------
+# core_session_metadata_write
+# ---------------------------------------------------------------------------
+
+test_that("core_session_metadata_write serialises provenance to JSON", {
+  tf <- tempFolders[44]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  meta <- SEMseeker:::core_session_metadata_write(tf, sample_n = 7L)
+
+  jf <- file.path(tf, "session_metadata.json")
+  expect_true(file.exists(jf))
+  parsed <- jsonlite::fromJSON(jf)
+  expect_equal(parsed$sample_n, 7L)
+  expect_true(nzchar(parsed$genome_build))
+  expect_true(nzchar(parsed$semseeker_version))
+  expect_equal(meta$sample_n, 7L)   # returned invisibly
+})
+
+# ---------------------------------------------------------------------------
+# core_pivot_sidecar_write
+# ---------------------------------------------------------------------------
+
+test_that("core_pivot_sidecar_write writes a _meta.json next to the pivot", {
+  tf <- tempFolders[45]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  pivot   <- file.path(tf, "MUTATIONS_HYPER_GENE_TSS1500_hg19.parquet")
+  SEMseeker:::core_pivot_sidecar_write(pivot)
+
+  sidecar <- file.path(tf, "MUTATIONS_HYPER_GENE_TSS1500_hg19_meta.json")
+  expect_true(file.exists(sidecar))
+  parsed <- jsonlite::fromJSON(sidecar)
+  expect_equal(parsed$pivot_file, "MUTATIONS_HYPER_GENE_TSS1500_hg19.parquet")
+  expect_true(nzchar(parsed$genome_build))
+})
+
+# ---------------------------------------------------------------------------
+# core_check_session_compatibility
+# ---------------------------------------------------------------------------
+
+.write_session_meta <- function(dir, genome_build, tech) {
+  writeLines(
+    jsonlite::toJSON(list(genome_build = genome_build, tech = tech),
+                     auto_unbox = TRUE),
+    file.path(dir, "session_metadata.json"))
+}
+
+test_that("core_check_session_compatibility accepts matching provenance", {
+  d1 <- tempfile("studyA"); dir.create(d1)
+  d2 <- tempfile("studyB"); dir.create(d2)
+  on.exit(unlink(c(d1, d2), recursive = TRUE), add = TRUE)
+  .write_session_meta(d1, "hg19", "K450")
+  .write_session_meta(d2, "hg19", "K450")
+
+  res <- SEMseeker:::core_check_session_compatibility(c(d1, d2))
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 2L)
+  expect_true(all(res$genome_build == "hg19"))
+})
+
+test_that("core_check_session_compatibility stops on differing genome build", {
+  d1 <- tempfile("studyA"); dir.create(d1)
+  d2 <- tempfile("studyB"); dir.create(d2)
+  on.exit(unlink(c(d1, d2), recursive = TRUE), add = TRUE)
+  .write_session_meta(d1, "hg19", "K450")
+  .write_session_meta(d2, "hg38", "K450")
+
+  expect_error(SEMseeker:::core_check_session_compatibility(c(d1, d2)),
+               "genome_build differs")
+})
+
+test_that("core_check_session_compatibility warns on differing tech", {
+  d1 <- tempfile("studyA"); dir.create(d1)
+  d2 <- tempfile("studyB"); dir.create(d2)
+  on.exit(unlink(c(d1, d2), recursive = TRUE), add = TRUE)
+  .write_session_meta(d1, "hg19", "K450")
+  .write_session_meta(d2, "hg19", "K850")
+
+  expect_warning(SEMseeker:::core_check_session_compatibility(c(d1, d2)),
+                 "Technologies differ")
+})
+
+test_that("core_check_session_compatibility is a no-op for a single session", {
+  expect_null(SEMseeker:::core_check_session_compatibility("only_one_folder"))
+})
+
+# ---------------------------------------------------------------------------
+# assoc_quantreg_metrics
+# ---------------------------------------------------------------------------
+
+test_that("assoc_quantreg_metrics computes pinball loss and QQ metrics", {
+  tf <- tempFolders[46]
+  SEMseeker:::core_init_env(result_folder = tf, start_fresh = TRUE)
+  on.exit({ SEMseeker:::core_close_env(); unlink(tf, recursive = TRUE) }, add = TRUE)
+
+  out <- SEMseeker:::assoc_quantreg_metrics(
+    predicted_values     = c(1, 2, 3),
+    expected_values      = c(1, 2, 4),
+    tau                  = 0.5,
+    res                  = data.frame(seed = 1),
+    family_test          = "quantreg_0.5",
+    independent_variable = "x",
+    transformation_y     = "",
+    dependent_variable   = "y",
+    plot                 = FALSE)
+
+  expect_true(all(c("pinball_loss", "below_quantile", "qq_distance",
+                    "qq_correlation") %in% colnames(out)))
+  # residuals = c(0,0,1); tau=0.5 -> only the +1 residual contributes 0.5
+  expect_equal(out$pinball_loss, 0.5)
+  expect_equal(out$below_quantile, 2 / 3)
+})

--- a/tests/testthat/test-8-burden-integration.R
+++ b/tests/testthat/test-8-burden-integration.R
@@ -57,6 +57,12 @@
   list(signal = local_sig, samples = local_samples, probes = local_probes)
 }
 
+.burden_required_markers <- c("MUTATIONS",
+                              "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
+                              "DELTAS", "DELTAR")
+.burden_cols <- c(paste0(.burden_required_markers, "_HYPER"),
+                  paste0(.burden_required_markers, "_HYPO"))
+
 test_that("sample_sheet_result.csv has populated burden columns for all discrete + continuous markers (AI-086, canary for AI-083)", {
   tempFolder <- tempFolders[1]
   tempFolders <<- tempFolders[-1]
@@ -220,4 +226,119 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
   }
 
   unlink(tempFolder, recursive = TRUE)
+})
+
+# ---------------------------------------------------------------------------
+# AI-083 hardening. The canary above runs on GSM-style identifiers in a clean
+# session; this block covers what it cannot see:
+#
+#   (a) identifiers that core_name_cleaning() actually rewrites — the
+#       ewas_osteoporosis/GSE99624 case was "DNAm_sample1" -> "DNAM_SAMPLE1";
+#   (b) a `temp_result` object left in the global environment. The old code
+#       used exists("temp_result"), which resolves through globalenv(). This
+#       is NOT sufficient on its own to produce the reported symptom (the
+#       inner merge uses all=TRUE, so a stray object only adds a spurious row),
+#       but the accumulator must be a local binding regardless;
+#   (c) the condition that DOES produce the reported symptom — a burden table
+#       sharing no Sample_ID with the sample sheet. The all.x=TRUE merge then
+#       yields 100% NA burden columns while PROBES_COUNT stays populated, and
+#       every depth=1 inference downstream dies with "data are not the same
+#       size". sem_study_summary_total() must refuse to write that file.
+# ---------------------------------------------------------------------------
+
+test_that("burden survives mixed-case Sample_IDs and a polluted global temp_result (AI-083)", {
+  tempFolder <- tempFolders[1]
+  tempFolders <<- tempFolders[-1]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({
+    try(SEMseeker:::core_close_env(), silent = TRUE)
+    if (exists("temp_result", envir = globalenv(), inherits = FALSE))
+      rm("temp_result", envir = globalenv())
+    unlink(tempFolder, recursive = TRUE)
+  }, add = TRUE)
+
+  syn <- .burden_setup_signal_with_outliers()
+
+  # ewas_osteoporosis-style identifiers: core_name_cleaning() uppercases them
+  # ("DNAm_sample1" -> "DNAM_SAMPLE1"), so sample sheet and pivot columns must
+  # still meet after normalisation.
+  raw_ids <- paste0("DNAm_sample", seq_len(ncol(syn$signal)))
+  id_map  <- stats::setNames(raw_ids, colnames(syn$signal))
+  sig     <- syn$signal
+  sheet   <- syn$samples
+  colnames(sig)   <- unname(id_map[colnames(sig)])
+  sheet$Sample_ID <- unname(id_map[sheet$Sample_ID])
+
+  # (b) pollute globalenv BEFORE the run: the object name collides with the
+  # accumulator inside sem_study_summary_total().
+  assign("temp_result",
+         data.frame(Sample_ID = "NOT_A_REAL_SAMPLE", JUNK = 1,
+                    stringsAsFactors = FALSE),
+         envir = globalenv())
+
+  SEMseeker::semseeker(
+    input             = sig,
+    sample_sheet      = sheet,
+    result_folder     = tempFolder,
+    parallel_strategy = "sequential",
+    areas             = c("POSITION"),
+    markers           = c("MUTATIONS", "LESIONS",
+                          "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
+                          "DELTAS", "DELTAR"),
+    start_fresh       = TRUE,
+    inpute            = "median",
+    showprogress      = showprogress,
+    verbosity         = verbosity
+  )
+
+  result_csv <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
+  testthat::expect_true(file.exists(result_csv))
+  testthat::skip_if_not(file.exists(result_csv),
+                        "downstream assertions need the result CSV")
+
+  df <- utils::read.csv2(result_csv, stringsAsFactors = FALSE)
+
+  # identifiers landed normalised on both sides
+  testthat::expect_true(all(grepl("^DNAM_SAMPLE", df$Sample_ID)))
+
+  present <- intersect(.burden_cols, colnames(df))
+  testthat::expect_gt(length(present), 0L)
+
+  # the AI-083 signature is 100% NA on every burden column at once
+  na_fraction <- vapply(df[present], function(x) mean(is.na(x)), numeric(1))
+  testthat::expect_false(
+    all(na_fraction == 1),
+    info = sprintf("all burden columns are 100%% NA: %s",
+                   paste(names(na_fraction), collapse = ", "))
+  )
+  testthat::expect_lt(
+    mean(na_fraction), 0.5,
+    label = sprintf("mean NA fraction across burden columns (%.2f)",
+                    mean(na_fraction))
+  )
+  testthat::expect_true(all(df$PROBES_COUNT > 0L, na.rm = TRUE))
+
+  # (c) the actual AI-083 signature: rewrite the sample sheet with identifiers
+  # that exist in no pivot, then re-run the aggregation. Before the guard this
+  # silently produced a sample sheet with 100% NA burden; now it must stop and
+  # name both sides.
+  df_broken <- df
+  df_broken$Sample_ID <- paste0("UNRELATED_", seq_len(nrow(df_broken)))
+  utils::write.csv2(df_broken, result_csv, row.names = FALSE)
+
+  SEMseeker:::core_init_env(
+    result_folder     = tempFolder,
+    parallel_strategy = "sequential",
+    areas             = c("POSITION"),
+    markers           = c("MUTATIONS", "LESIONS",
+                          "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
+                          "DELTAS", "DELTAR"),
+    start_fresh       = FALSE,
+    showprogress      = FALSE,
+    verbosity         = 1
+  )
+  testthat::expect_error(
+    SEMseeker:::sem_study_summary_total(),
+    "no Sample_ID in common"
+  )
 })


### PR DESCRIPTION
## Behaviour changes (read first)

Three changes in this branch can stop a pipeline that used to run:

1. **Coverage gate (AI-074).** Every SEM analysis now runs a coverage check
   before detection. The run **stops** when fewer than `coverage_minimum`
   percent (default **80**) of the input positions are found in the reference
   annotation. Lower it explicitly for deliberate cross-technology runs.
   Coordinate-based technologies (WGBS, long reads) are exempt.
   The coverage charts are written on every run, including rejected ones.
2. **Burden guard (AI-083).** `sem_study_summary_total()` now stops when the
   sample sheet and the POSITION pivots share no `Sample_ID`, instead of
   writing a sample sheet whose burden columns are 100% `NA`.
3. **Sample-id normalisation (AI-224).** Sheet identifiers and signal column
   names are normalised through one helper. Identifiers that would collapse
   onto the same normalised name, and identifiers with no matching signal
   column, are now reported as errors instead of surfacing later as
   `undefined columns selected`.

## Fixes

- **AI-224** — cleaned signal column names were compared with raw sample-sheet
  identifiers. With identifiers such as `C3L-00001-06` the two sides never
  matched: `util_exploratory_analysis()` wrote a cleaned parquet holding only
  the `PROBE` column and the SEM path failed with `undefined columns selected`.
  Invisible until now because every dataset used so far has `GSM\d+` ids, on
  which the cleaning is a no-op.
- **AI-083** — see above. The originally reported case no longer reproduces on
  current code (verified with a full run on both id styles: 14 burden columns,
  NA fraction 0); the guard covers the condition that produces the symptom.
- **AI-074** — the coverage charts were in fact never produced on a default
  run: `areas` defaults to `POSITION` only and the coverage report skips
  `POSITION`/`PROBE`. Coverage now reports on the full annotation set.
- **AI-119** — `inst/CITATION` pointed at a Bioconductor DOI that does not
  resolve; it now carries the Zenodo concept DOI `10.5281/zenodo.5095417`.

## Tests

New: `test-0-coverage-gate.R`, `test-0-sample_id_normalization.R`;
`test-8-burden-integration.R` extended (mixed-case ids, polluted global,
total mismatch). Plus the original coverage expansion of this branch
(+29 helpers/models, 8 new test files).

Local run before push: 13 test files, **0 failed / 0 error**, including
`test-6-semseeker` (98), `test-7-association_analysis` (38) and
`test-cross-format-convergence` (11, run with `NOT_CRAN=true`).