### PR TITLE
feat: per-sample statistics sibling, scope SAMPLE (AI-223 slice 1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,32 @@
 
 ## semseeker 0.99.3
 
+### Breaking changes
+
+- **The per-sample burden moved out of `SAMPLE_SHEET_RESULT.csv` into a new
+  sibling file, `SAMPLE_STATS_RESULT.csv` (AI-223).** The columns that used to
+  be appended to the sample sheet (`MUTATIONS_HYPER`, `DELTAS_HYPO`, …, and
+  `PROBES_COUNT`) were aggregated over every probe with no genomic filter —
+  that is the *sample* scope of the new artefact — and are now written there as
+  `SAMPLE_<MARKER>_<FIGURE>` and `SAMPLE_N_PROBES`. The sample sheet stays the
+  description of the study; the two files join on `Sample_ID`, and
+  `sem_study_summary_get()` performs that join for you, so analyses inside the
+  package are unaffected. Code that read the burden straight from
+  `SAMPLE_SHEET_RESULT.csv` must read the sibling instead.
+
 ### New features
+
+- **Per-sample signal descriptors (AI-223).** Alongside the burden, the new
+  sibling carries `SAMPLE_MEDIAN`, `SAMPLE_MEAN`, `SAMPLE_VARIANCE`,
+  `SAMPLE_IQR` and `SAMPLE_N_PROBES` for every sample. On the beta scale it
+  also carries the two modes of the bimodal distribution, `SAMPLE_MODE_LOW` and
+  `SAMPLE_MODE_HIGH`, estimated as the highest density peak on each side of
+  0.5. On M-values the distribution is unimodal and the split carries no
+  meaning, so the two columns are omitted rather than filled with a
+  meaningless number. Column names are composed by a single shared helper, so
+  producer and consumer cannot drift apart. Region scopes
+  (`<AREA>[_<SUBAREA>]_*`) are the next step; the naming already accommodates
+  them.
 
 - **Coverage is now a mandatory pre-step of every SEM analysis (AI-074).**
   Coverage used to be an opt-in report, so a run could go straight to SEM

--- a/R/io_stat_colname.R
+++ b/R/io_stat_colname.R
@@ -1,0 +1,63 @@
+#' Column names of the per-sample statistics sibling (internal)
+#'
+#' AI-223. The sibling artefact (`SAMPLE_STATS_RESULT.csv`) is the contract
+#' between production (annotation + aggregation, inside `semseeker()`) and
+#' consumption (`association_analysis()`). Both sides MUST compose its column
+#' names through these helpers: if producer and consumer built the strings
+#' independently, the contract would break at the first divergence.
+#'
+#' Naming, all uppercase via [core_name_cleaning()]:
+#' \itemize{
+#'   \item scope — `SAMPLE` (whole sample, no genomic filter), `<AREA>`, or
+#'     `<AREA>_<SUBAREA>`;
+#'   \item signal descriptors (marker-independent) — `<SCOPE>_<STAT>`, e.g.
+#'     `SAMPLE_MEDIAN`, `GENE_BODY_IQR`;
+#'   \item burden per marker — `<SCOPE>_<MARKER>_<FIGURE>`, e.g.
+#'     `SAMPLE_MUTATIONS_HYPER`.
+#' }
+#'
+#' @keywords internal
+#' @noRd
+io_scope_name <- function(depth = 1L, area = NULL, subarea = NULL) {
+  depth <- suppressWarnings(as.integer(depth))
+  if (length(depth) != 1L || is.na(depth)) depth <- 1L
+
+  if (depth <= 1L || is.null(area) || !nzchar(as.character(area)))
+    return("SAMPLE")
+
+  parts <- as.character(area)
+  if (depth >= 3L && !is.null(subarea) && nzchar(as.character(subarea)))
+    parts <- c(parts, as.character(subarea))
+
+  core_name_cleaning(paste(parts, collapse = "_"))
+}
+
+#' @keywords internal
+#' @noRd
+io_stat_colname <- function(scope, stat) {
+  if (missing(scope) || is.null(scope) || !nzchar(scope))
+    stop("io_stat_colname(): 'scope' is required (use io_scope_name()).")
+  core_name_cleaning(paste(scope, stat, sep = "_"))
+}
+
+#' @keywords internal
+#' @noRd
+io_burden_colname <- function(scope, marker, figure) {
+  if (missing(scope) || is.null(scope) || !nzchar(scope))
+    stop("io_burden_colname(): 'scope' is required (use io_scope_name()).")
+  core_name_cleaning(paste(scope, marker, figure, sep = "_"))
+}
+
+#' Statistics emitted for a signal scope
+#'
+#' MODE_LOW / MODE_HIGH only make sense on a bounded, bimodal scale (beta in
+#' [0,1], the two peaks around 0 and 1). On M-values the distribution is
+#' roughly gaussian and the two-mode split carries no meaning, so the columns
+#' are omitted rather than filled with a meaningless number.
+#'
+#' @keywords internal
+#' @noRd
+io_signal_stats <- function(beta = TRUE) {
+  base <- c("MEDIAN", "MEAN", "VARIANCE", "IQR", "N_PROBES")
+  if (isTRUE(beta)) c(base, "MODE_LOW", "MODE_HIGH") else base
+}

--- a/R/sem_core.R
+++ b/R/sem_core.R
@@ -56,6 +56,10 @@ sem_core <- function(sample_sheet,
 
   sem_deltaX_get()
   sem_study_summary_total()
+  # AI-223: per-sample statistics sibling (burden + signal descriptors),
+  # written next to the sample sheet and joined back on Sample_ID by
+  # sem_study_summary_get().
+  sem_sample_stats_build()
   anno_annotate_position_pivots()
 
   # Single point of sidecar materialisation (AI-027).

--- a/R/sem_run_depth1_marker.R
+++ b/R/sem_run_depth1_marker.R
@@ -21,11 +21,21 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   results <- data.frame()
   processed_items <- 0L
 
-  cols <- keys$COMBINED
-  if (sum(cols %in% colnames(prep$study_summary)) == 0)
+  # AI-223: the sample-level burden lives in the statistics sibling, joined
+  # onto study_summary by sem_study_summary_get() under the SAMPLE scope. Its
+  # column names are composed with the shared helper — never hard-coded — and
+  # renamed back to <MARKER>_<FIGURE> below so the inference output (AREA_OF_TEST)
+  # keeps its historical values.
+  cols        <- keys$COMBINED
+  burden_cols <- io_burden_colname("SAMPLE", keys$MARKER, keys$FIGURE)
+  present     <- burden_cols %in% colnames(prep$study_summary)
+  if (sum(present) == 0)
     return(list(results = results, processed_items = processed_items))
 
-  cols          <- cols[cols %in% colnames(prep$study_summary)]
+  keys        <- keys[present, , drop = FALSE]
+  cols        <- cols[present]
+  burden_cols <- burden_cols[present]
+  prep$study_summary <- .sem_burden_cols_rename(prep$study_summary, burden_cols, cols)
   keys$AREA     <- "SAMPLE_GROUP"
   keys$SUBAREA  <- "SAMPLE"
 
@@ -58,7 +68,14 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
       g_start <- 2 + length(prep$covariates)
       column_selectors <- c(prep$independent_variable, prep$covariates, key$COMBINED)
       column_selectors <- column_selectors[column_selectors != ""]
-      processed_items <- processed_items + ncol(study_summary_local) - g_start
+      # One key at depth=1 means exactly one test: a single burden column is
+      # fitted against the independent variable. The counter used to take
+      # ncol(study_summary_local), i.e. the width of the WHOLE sample sheet,
+      # which counted phenotype columns as if they had been tested (and, since
+      # AI-223 joins the statistics sibling, the signal descriptors too).
+      # Depth>1 counts the tested columns of its batch frame; this is the
+      # depth=1 equivalent.
+      processed_items <- processed_items + 1L
       if (any(is.na(study_summary_local[, column_selectors]))) {
         core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
           " Missing values in the data frame!")
@@ -97,4 +114,27 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   assoc_analysis_save_results(results, fileNameResults, family_test, filter_p_value)
 
   list(results = results, processed_items = processed_items)
+}
+
+#' Rename the SAMPLE-scope burden columns back to <MARKER>_<FIGURE>
+#'
+#' AI-223. The statistics sibling stores the sample-level burden as
+#' `SAMPLE_<MARKER>_<FIGURE>`; the models and the inference output have always
+#' referred to it as `<MARKER>_<FIGURE>` (it becomes AREA_OF_TEST in the
+#' results). Renaming at the boundary keeps the artefact naming explicit about
+#' its scope without changing what the results look like.
+#'
+#' @keywords internal
+#' @noRd
+.sem_burden_cols_rename <- function(study_summary, from, to) {
+  if (is.null(study_summary) || length(from) == 0)
+    return(study_summary)
+  # drop any stale column that would collide with the target name
+  collisions <- intersect(to, colnames(study_summary))
+  if (length(collisions) > 0)
+    study_summary <- study_summary[, !(colnames(study_summary) %in% collisions), drop = FALSE]
+  idx <- match(from, colnames(study_summary))
+  keep <- !is.na(idx)
+  colnames(study_summary)[idx[keep]] <- to[keep]
+  study_summary
 }

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -1,0 +1,260 @@
+#' Per-sample statistics sibling of the sample sheet (internal)
+#'
+#' AI-223, slice 1 — scope `SAMPLE`. Produces `SAMPLE_STATS_RESULT.csv` next to
+#' `SAMPLE_SHEET_RESULT.csv` in the data folder, one row per sample, wide:
+#'
+#' \itemize{
+#'   \item burden per marker — `SAMPLE_<MARKER>_<FIGURE>`, aggregated over the
+#'     `AREA == "POSITION"` keys (i.e. every probe, no genomic filter). The
+#'     operator is intrinsic to the marker: discrete markers are summed,
+#'     continuous ones averaged;
+#'   \item signal descriptors — `SAMPLE_MEDIAN`, `SAMPLE_MEAN`,
+#'     `SAMPLE_VARIANCE`, `SAMPLE_IQR`, plus `SAMPLE_MODE_LOW` /
+#'     `SAMPLE_MODE_HIGH` on the beta scale only;
+#'   \item `SAMPLE_N_PROBES`.
+#' }
+#'
+#' Keeping these out of the sample sheet is deliberate: the sheet stays the
+#' description of the study, this file carries what the run computed, and the
+#' two join on `Sample_ID`. Region scopes (`<AREA>[_<SUBAREA>]_*`) are the next
+#' slice; the column naming already accommodates them through
+#' [io_scope_name()].
+#'
+#' @return Invisibly the path of the file written, or `NULL` when there was
+#'   nothing to write.
+#' @keywords internal
+#' @noRd
+#' @importFrom doRNG %dorng%
+sem_sample_stats_build <- function() {
+
+  ssEnv <- core_get_session_info()
+
+  burden      <- .sem_sample_burden_get()
+  descriptors <- .sem_sample_descriptors_get()
+
+  if (is.null(burden) && is.null(descriptors)) {
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " No per-sample statistics could be computed; ",
+              "SAMPLE_STATS_RESULT not written.")
+    return(invisible(NULL))
+  }
+
+  stats <- if (is.null(burden)) descriptors else
+           if (is.null(descriptors)) burden else
+           merge(descriptors, burden, by = "Sample_ID", all = TRUE)
+
+  # Sample sheet identifiers are the reference: report what the pivots know
+  # about samples the sheet does not mention, and vice versa (AI-083).
+  sheet <- sem_study_summary_get(with_sample_stats = FALSE)
+  if (!is.null(sheet) && "Sample_ID" %in% colnames(sheet)) {
+    ids_sheet <- unique(as.character(sheet$Sample_ID))
+    ids_stats <- unique(as.character(stats$Sample_ID))
+    if (length(intersect(ids_sheet, ids_stats)) == 0) {
+      core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"),
+                " Per-sample statistics match no sample of the sample sheet: [",
+                paste(utils::head(ids_sheet, 4), collapse = ", "), "] vs [",
+                paste(utils::head(ids_stats, 4), collapse = ", "), "].")
+      stop("sem_sample_stats_build(): no Sample_ID in common between the sample ",
+           "sheet and the computed pivots. Sample sheet ids: ",
+           paste(utils::head(ids_sheet, 4), collapse = ", "),
+           " | pivot columns: ", paste(utils::head(ids_stats, 4), collapse = ", "), ".")
+    }
+    missing_ids <- setdiff(ids_sheet, ids_stats)
+    if (length(missing_ids) > 0)
+      core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+                " ", length(missing_ids), " sample(s) have no computed statistics: ",
+                paste(utils::head(missing_ids, 10), collapse = ", "),
+                if (length(missing_ids) > 10) ", ..." else "")
+  }
+
+  stats <- stats[order(stats$Sample_ID), , drop = FALSE]
+  file_path <- io_file_path_build(ssEnv$result_folderData, "sample_stats_result", "csv")
+  utils::write.csv2(stats, file_path, row.names = FALSE)
+  core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
+            " Per-sample statistics written: ", nrow(stats), " samples x ",
+            ncol(stats) - 1, " columns.")
+
+  invisible(file_path)
+}
+
+#' Burden per marker at sample level
+#'
+#' Moved here from sem_study_summary_total() (AI-223): the columns it used to
+#' append to the sample sheet were aggregated over the `POSITION` keys, i.e.
+#' they were already the `SAMPLE` scope of this artefact.
+#'
+#' @keywords internal
+#' @noRd
+.sem_sample_burden_get <- function() {
+
+  ssEnv <- core_get_session_info()
+  keys <- ssEnv$keys_areas_subareas_markers_figures
+  keys <- subset(keys, keys$AREA == "POSITION")
+  if (nrow(keys) == 0)
+    return(NULL)
+
+  result <- NULL
+  for (k in seq_len(nrow(keys))) {
+    key     <- keys[k, ]
+    marker  <- key$MARKER
+    figure  <- key$FIGURE
+
+    pivot <- io_read_pivot(marker, figure, key$AREA, key$SUBAREA)
+    if (is.null(pivot))
+      next
+
+    pivot <- pivot$drop(c("CHR", "START", "END"))
+    # The operator is intrinsic to the marker: counts are summed, continuous
+    # deviations averaged. DISCRETE is the flag that already encodes it
+    # (util_keys_create.R).
+    pivot <- if (isTRUE(key$DISCRETE)) pivot$sum() else pivot$mean()
+    pivot <- pivot$with_columns(polars::pl$col("*"))
+
+    pivot <- as.data.frame(t(as.data.frame(pivot$collect())))
+    colname <- io_burden_colname("SAMPLE", marker, figure)
+    colnames(pivot) <- colname
+    pivot$Sample_ID <- rownames(pivot)
+
+    if (is.null(result)) {
+      result <- pivot
+    } else {
+      result <- result[, !(colnames(result) == colname), drop = FALSE]
+      result <- merge(result, pivot, by = "Sample_ID", all = TRUE)
+    }
+  }
+
+  if (is.null(result))
+    return(NULL)
+
+  result[is.na(result)] <- 0
+  rownames(result) <- NULL
+  result
+}
+
+#' Signal descriptors at sample level
+#'
+#' One pass per sample over the SIGNAL pivot, parallelised with the same
+#' foreach/%dorng% idiom used elsewhere in the package. Each worker collects a
+#' single sample column (one column ~ n_probes doubles, so memory stays bounded
+#' by the number of workers, not by the size of the matrix) and reduces it to
+#' one row of statistics.
+#'
+#' @keywords internal
+#' @noRd
+.sem_sample_descriptors_get <- function() {
+
+  ssEnv <- core_get_session_info()
+
+  pivot_path <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE", "WHOLE")
+  if (!file.exists(pivot_path)) {
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " SIGNAL pivot not found, signal descriptors skipped: ", pivot_path)
+    return(NULL)
+  }
+
+  lazy <- polars::pl$scan_parquet(pivot_path)
+  # The probe identifier column is named AREA in the PROBE pivot
+  # (io_signal_save()); every other column is a sample.
+  samples <- setdiff(names(lazy$collect_schema()), c("AREA", "PROBE", "CHR", "START", "END"))
+  if (length(samples) == 0) {
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " SIGNAL pivot carries no sample column; descriptors skipped.")
+    return(NULL)
+  }
+
+  beta  <- isTRUE(ssEnv$beta)
+  stats_wanted <- io_signal_stats(beta)
+  colnames_out <- vapply(stats_wanted, function(s) io_stat_colname("SAMPLE", s),
+                         character(1))
+
+  core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
+            " Computing signal descriptors for ", length(samples),
+            " samples (scale: ", if (beta) "beta" else "M-value", ").")
+
+  s <- NULL   # quiet R CMD check note
+  descriptors <- foreach::foreach(
+    s         = seq_along(samples),
+    .combine  = rbind,
+    .packages = c("SEMseeker", "polars", "stats"),
+    .export   = c("samples", "pivot_path", "beta", "stats_wanted", "colnames_out")
+  ) %dorng% tryCatch({
+    sample_id <- samples[s]
+    values <- as.data.frame(
+      polars::pl$scan_parquet(pivot_path)$select(sample_id)$collect()
+    )[[1]]
+    values <- as.numeric(values)
+    values <- values[is.finite(values)]
+
+    row <- SEMseeker:::.sem_signal_descriptors(values, beta = beta)
+    out <- data.frame(Sample_ID = sample_id, stringsAsFactors = FALSE)
+    for (i in seq_along(stats_wanted)) {
+      # NULL would DROP the column instead of filling it, and rows of unequal
+      # width break the rbind combine.
+      value <- row[[stats_wanted[i]]]
+      out[[colnames_out[i]]] <- if (is.null(value)) NA_real_ else value
+    }
+    out
+  }, error = function(e) {
+    NULL
+  })
+
+  if (is.null(descriptors) || nrow(descriptors) == 0)
+    return(NULL)
+
+  rownames(descriptors) <- NULL
+  descriptors
+}
+
+#' Reduce one sample's signal vector to its descriptors
+#'
+#' Split at 0.5 for the two beta modes: methylation beta values are bimodal
+#' with peaks near 0 (unmethylated) and near 1 (methylated), so the highest
+#' density peak on each side of 0.5 is the natural estimate of each mode. On
+#' M-values the distribution is unimodal and the split is meaningless, which is
+#' why [io_signal_stats()] does not request the mode columns there.
+#'
+#' @param values numeric vector, already filtered to finite values.
+#' @param beta logical. TRUE when the signal is on the [0,1] beta scale.
+#' @return named list of statistics.
+#' @keywords internal
+#' @noRd
+.sem_signal_descriptors <- function(values, beta = TRUE) {
+
+  out <- list(
+    MEDIAN     = NA_real_,
+    MEAN       = NA_real_,
+    VARIANCE   = NA_real_,
+    IQR        = NA_real_,
+    N_PROBES   = length(values)
+  )
+
+  if (length(values) == 0)
+    return(out)
+
+  out$MEDIAN   <- stats::median(values)
+  out$MEAN     <- mean(values)
+  out$VARIANCE <- stats::var(values)
+  out$IQR      <- stats::IQR(values)
+
+  if (!isTRUE(beta))
+    return(out)
+
+  out$MODE_LOW  <- NA_real_
+  out$MODE_HIGH <- NA_real_
+  # density() needs at least two distinct points to estimate anything.
+  if (length(unique(values)) < 2L)
+    return(out)
+
+  dens <- tryCatch(stats::density(values, from = 0, to = 1),
+                   error = function(e) NULL)
+  if (is.null(dens))
+    return(out)
+
+  low <- dens$x < 0.5
+  if (any(low))
+    out$MODE_LOW <- dens$x[low][which.max(dens$y[low])]
+  if (any(!low))
+    out$MODE_HIGH <- dens$x[!low][which.max(dens$y[!low])]
+
+  out
+}

--- a/R/sem_study_summary_get.R
+++ b/R/sem_study_summary_get.R
@@ -1,4 +1,14 @@
-sem_study_summary_get <- function(sql_sample_selection="")
+#' Read the study sample sheet, optionally joined with the statistics sibling
+#'
+#' @param sql_sample_selection filter applied via [assoc_filter_sql()].
+#' @param with_sample_stats logical. When `TRUE` (default) the per-sample
+#'   statistics produced by `sem_sample_stats_build()` are LEFT JOINed on
+#'   `Sample_ID`, so consumers see `SAMPLE_<MARKER>_<FIGURE>` and
+#'   `SAMPLE_<STAT>` as ordinary columns (AI-223). The producers of the two
+#'   files call it with `FALSE` to avoid feeding their own output back in.
+#' @keywords internal
+#' @noRd
+sem_study_summary_get <- function(sql_sample_selection="", with_sample_stats = TRUE)
 {
   ssEnv <- core_get_session_info()
   # io_file_path_build() uppercases via core_name_cleaning() — the on-disk file is
@@ -27,5 +37,42 @@ sem_study_summary_get <- function(sql_sample_selection="")
   if(nrow(reference)==0)
     study_summary <- no_reference
 
+  # AI-223: the burden and the signal descriptors live in the sibling; join
+  # them here so every consumer keeps seeing one table.
+  if (isTRUE(with_sample_stats))
+    study_summary <- .sem_study_summary_join_stats(study_summary)
+
   return(study_summary)
+}
+
+#' LEFT JOIN of the per-sample statistics sibling onto the sample sheet
+#'
+#' Silent no-op when the sibling has not been produced (e.g. a session that
+#' only ran the exploratory step, or a result folder from an older version):
+#' the sample sheet is still perfectly usable on its own, callers that need the
+#' burden check for their columns.
+#'
+#' @keywords internal
+#' @noRd
+.sem_study_summary_join_stats <- function(study_summary) {
+
+  if (is.null(study_summary) || !("Sample_ID" %in% colnames(study_summary)))
+    return(study_summary)
+
+  ssEnv <- core_get_session_info()
+  stats_file <- io_file_path_build(ssEnv$result_folderData, "sample_stats_result", "csv")
+  if (!file.exists(stats_file))
+    return(study_summary)
+
+  stats <- tryCatch(utils::read.csv2(stats_file, stringsAsFactors = FALSE),
+                    error = function(e) NULL)
+  if (is.null(stats) || !("Sample_ID" %in% colnames(stats)) || nrow(stats) == 0)
+    return(study_summary)
+
+  # Never let the sibling shadow a column of the sample sheet.
+  duplicated_cols <- setdiff(intersect(colnames(stats), colnames(study_summary)), "Sample_ID")
+  if (length(duplicated_cols) > 0)
+    stats <- stats[, !(colnames(stats) %in% duplicated_cols), drop = FALSE]
+
+  merge(study_summary, stats, by = "Sample_ID", all.x = TRUE)
 }

--- a/R/sem_study_summary_total.R
+++ b/R/sem_study_summary_total.R
@@ -1,97 +1,33 @@
+#' Write the study sample sheet of the run (internal)
+#'
+#' AI-223: this function used to append the per-sample burden
+#' (`MUTATIONS_HYPER`, `DELTAS_HYPO`, …) and `PROBES_COUNT` to the sample
+#' sheet. Those columns were aggregated over the `AREA == "POSITION"` keys —
+#' i.e. over every probe, with no genomic filter — which is exactly the
+#' `SAMPLE` scope of the statistics sibling. They now live in
+#' `SAMPLE_STATS_RESULT.csv` (see `sem_sample_stats_build()`), named
+#' `SAMPLE_<MARKER>_<FIGURE>` / `SAMPLE_N_PROBES`, and the sample sheet stays
+#' the description of the study. The two join on `Sample_ID`.
+#'
+#' @return Invisibly the path of the file written.
+#' @keywords internal
+#' @noRd
 sem_study_summary_total <- function()
 {
-
   ssEnv <- core_get_session_info()
-  study_summary <- sem_study_summary_get()
+  study_summary <- sem_study_summary_get(with_sample_stats = FALSE)
 
-  # ssEnv <- core_get_session_info()
-  keys <- ssEnv$keys_areas_subareas_markers_figures
-  keys <- subset(keys, AREA=="POSITION")
-  if(nrow(keys)==0)
-    return()
-
-  # AI-083: temp_result MUST be a local binding initialised here. The previous
-  # code used exists("temp_result"), which resolves through the enclosing
-  # environments up to globalenv(): a leftover object of that name in an
-  # interactive session (or restored from a .RData) made the first iteration
-  # take the merge branch against an unrelated data frame, so every burden
-  # column landed as NA while PROBES_COUNT (assigned unconditionally below)
-  # stayed populated — exactly the reported symptom.
-  temp_result <- NULL
-
-  for ( k in seq_len(nrow(keys)))
-  {
-    # k <- 1
-    key <- keys[k,]
-    marker <- key$MARKER
-    figure <- key$FIGURE
-    area <- key$AREA
-    subarea <- key$SUBAREA
-    # AI-027: read via unified dispatcher. NULL means no pivot AND no
-    # streaming-merge source — skip the key with the same semantics as
-    # the previous file.exists() guard.
-    pivot <- io_read_pivot(marker, figure, area, subarea)
-    if (is.null(pivot))
-      next
-    # remove CHR START END columns
-    pivot <- pivot$drop(c("CHR", "START", "END"))
-    # sum per columns
-    if(key$DISCRETE)
-      pivot <- pivot$sum()$with_columns(polars::pl$col("*"))
-    else
-      pivot <- pivot$mean()$with_columns(polars::pl$col("*"))
-
-    pivot <- as.data.frame(t(as.data.frame(pivot$collect())))
-    combined_key <- paste0(marker,"_",figure)
-    colnames(pivot) <- combined_key
-    pivot$Sample_ID <- row.names(pivot)
-
-    if(is.null(temp_result))
-      temp_result <- pivot
-    else
-    {
-      temp_result <- temp_result[, !(colnames(temp_result) == combined_key), drop = FALSE]
-      temp_result <- merge(temp_result, pivot, by="Sample_ID", all=TRUE)
-    }
-  }
-  if (is.null(temp_result))
-    return()
-  temp_result[is.na(temp_result)] <- 0
-  # remove from summary all column excet Sample_ID from temp_result
-  col_temp <- colnames(temp_result)[!(colnames(temp_result) == "Sample_ID")]
-  study_summary <- study_summary[, !(colnames(study_summary) %in% col_temp)]
-
-  # AI-083: the burden merge is name-based. If the two sides share no
-  # Sample_ID the all.x=TRUE merge silently yields a sample sheet whose burden
-  # columns are 100% NA (PROBES_COUNT below still gets filled), which then
-  # crashes every depth=1 inference downstream with "data are not the same
-  # size". Fail here, naming both sides, instead of writing that file.
-  ids_summary <- as.character(study_summary$Sample_ID)
-  ids_burden  <- as.character(temp_result$Sample_ID)
-  matched     <- intersect(ids_summary, ids_burden)
-  if (length(matched) == 0) {
-    core_log_event("ERROR: ", format(Sys.time(), "%a %b %d %X %Y"),
-              " Burden aggregation matches no sample: sample sheet ids [",
-              paste(utils::head(ids_summary, 4), collapse = ", "),
-              "] vs pivot columns [",
-              paste(utils::head(ids_burden, 4), collapse = ", "), "].")
-    stop("sem_study_summary_total(): no Sample_ID in common between the sample ",
-         "sheet and the POSITION pivots — the burden columns would all be NA. ",
-         "Sample sheet ids: ", paste(utils::head(ids_summary, 4), collapse = ", "),
-         " | pivot columns: ", paste(utils::head(ids_burden, 4), collapse = ", "), ".")
-  }
-  missing_ids <- setdiff(unique(ids_summary), ids_burden)
-  if (length(missing_ids) > 0)
+  if (is.null(study_summary) || nrow(study_summary) == 0) {
     core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
-              " ", length(missing_ids), " sample(s) have no burden in the POSITION pivots: ",
-              paste(utils::head(missing_ids, 10), collapse = ", "),
-              if (length(missing_ids) > 10) ", ..." else "")
+              " No sample sheet available; SAMPLE_SHEET_RESULT not written.")
+    return(invisible(NULL))
+  }
 
-  study_summary <- merge(study_summary, temp_result, by="Sample_ID", all.x=TRUE)
-  study_summary$PROBES_COUNT <- ssEnv$probes_count
   # io_file_path_build() uppercases via core_name_cleaning() — on-disk name is
   # SAMPLE_SHEET_RESULT.csv. Linux ext4 is case-sensitive; readers that
   # hard-code the path must use the uppercase form. See io_file_path_build().
   summary_file <- io_file_path_build( ssEnv$result_folderData, "sample_sheet_result","csv")
-  utils::write.csv2(study_summary,summary_file, row.names = FALSE)
+  utils::write.csv2(study_summary, summary_file, row.names = FALSE)
+
+  invisible(summary_file)
 }

--- a/tests/testthat/helper-burden.R
+++ b/tests/testthat/helper-burden.R
@@ -1,0 +1,48 @@
+# Shared fixture for the burden / per-sample statistics tests.
+# Lives in a helper because testthat isolates each test file's environment:
+# test-8-burden-integration.R and test-0-sample-stats-sibling.R both use it.
+
+.burden_setup_signal_with_outliers <- function(seed = 12345L) {
+  set.seed(seed)
+  n_probes_b  <- 200L
+  n_samples_b <- nsamples
+  local_probes  <- probe_features[1:n_probes_b, ]
+  local_samples <- mySampleSheet
+
+  # Background: mostly methylated (Beta(90, 10)).
+  # IMPORTANT: outliers are detected per-probe across samples (IQR × 3 on
+  # the inter-sample distribution). If we inject the SAME band across all
+  # samples uniformly, the per-probe q1/q3 collapse to that uniform value
+  # and IQR → 0 → no sample is flagged. So we inject DISJOINT, RANDOM
+  # per-sample probe sets — each sample is an outlier at probes the other
+  # samples are not, which is exactly the inter-sample dispersion the
+  # threshold needs.
+  local_sig <- matrix(
+    stats::rbeta(n_probes_b * n_samples_b, 90L, 10L),
+    nrow = n_probes_b, ncol = n_samples_b
+  )
+  for (s in seq_len(n_samples_b)) {
+    # 10 random HYPO probes from positions 1:100 → values ≈ 0
+    hypo_probes <- sample.int(100L, 10L)
+    local_sig[hypo_probes, s] <- stats::rbeta(10L, 1L, 100L)
+    # 10 random HYPER probes from positions 101:200 → values ≈ 1
+    hyper_probes <- 100L + sample.int(100L, 10L)
+    local_sig[hyper_probes, s] <- stats::rbeta(10L, 100L, 1L)
+  }
+
+  rownames(local_sig) <- local_probes$PROBE
+  local_sig <- as.data.frame(local_sig)
+  # signal_data has 10 unique columns; mySampleSheet has 16 rows (Reference reuse pattern)
+  colnames(local_sig) <- colnames(signal_data)
+  list(signal = local_sig, samples = local_samples, probes = local_probes)
+}
+
+.burden_required_markers <- c("MUTATIONS",
+                              "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
+                              "DELTAS", "DELTAR")
+# AI-223: the burden lives in the statistics sibling under the SAMPLE scope,
+# so the column names carry the scope prefix. Composed here the same way
+# io_burden_colname() composes them on the package side.
+.burden_cols <- paste0("SAMPLE_",
+                       c(paste0(.burden_required_markers, "_HYPER"),
+                         paste0(.burden_required_markers, "_HYPO")))

--- a/tests/testthat/test-0-sample-stats-sibling.R
+++ b/tests/testthat/test-0-sample-stats-sibling.R
@@ -1,0 +1,168 @@
+## AI-223 slice 1 — per-sample statistics sibling (scope SAMPLE).
+##
+## Contracts:
+##   1. column names come from ONE helper, used by producer and consumer alike;
+##   2. the sibling is written next to the sample sheet, one row per sample,
+##      carrying burden (SAMPLE_<MARKER>_<FIGURE>) and signal descriptors
+##      (SAMPLE_<STAT>);
+##   3. the two beta modes are estimated on each side of 0.5 and are omitted on
+##      the M-value scale, where the split carries no meaning;
+##   4. the sample sheet no longer carries the burden — it moved here;
+##   5. the sibling joins back onto the sample sheet on Sample_ID.
+##
+## Session test uses tempFolders index 13.
+
+# ---------------------------------------------------------------------------
+# naming helpers (pure)
+# ---------------------------------------------------------------------------
+
+test_that("io_scope_name encodes depth as scope", {
+  expect_equal(SEMseeker:::io_scope_name(1L), "SAMPLE")
+  expect_equal(SEMseeker:::io_scope_name(1L, "GENE", "BODY"), "SAMPLE")
+  expect_equal(SEMseeker:::io_scope_name(2L, "GENE", "BODY"), "GENE")
+  expect_equal(SEMseeker:::io_scope_name(3L, "GENE", "BODY"), "GENE_BODY")
+  # missing area falls back to sample level whatever the depth
+  expect_equal(SEMseeker:::io_scope_name(3L, "", ""), "SAMPLE")
+})
+
+test_that("io_stat_colname and io_burden_colname compose the documented names", {
+  expect_equal(SEMseeker:::io_stat_colname("SAMPLE", "MEDIAN"), "SAMPLE_MEDIAN")
+  expect_equal(SEMseeker:::io_stat_colname("GENE_BODY", "IQR"), "GENE_BODY_IQR")
+  expect_equal(
+    SEMseeker:::io_burden_colname("SAMPLE", "MUTATIONS", "HYPER"),
+    "SAMPLE_MUTATIONS_HYPER")
+  expect_equal(
+    SEMseeker:::io_burden_colname("GENE_BODY", "LESIONS", "HYPO"),
+    "GENE_BODY_LESIONS_HYPO")
+  # a scope is mandatory: an unscoped column would be ambiguous in the file
+  expect_error(SEMseeker:::io_stat_colname("", "MEDIAN"), "scope")
+  expect_error(SEMseeker:::io_burden_colname("", "MUTATIONS", "HYPER"), "scope")
+})
+
+test_that("io_signal_stats drops the two modes off the beta scale", {
+  expect_true(all(c("MODE_LOW", "MODE_HIGH") %in% SEMseeker:::io_signal_stats(beta = TRUE)))
+  expect_false(any(c("MODE_LOW", "MODE_HIGH") %in% SEMseeker:::io_signal_stats(beta = FALSE)))
+  expect_true(all(c("MEDIAN", "MEAN", "VARIANCE", "IQR", "N_PROBES") %in%
+                    SEMseeker:::io_signal_stats(beta = FALSE)))
+})
+
+# ---------------------------------------------------------------------------
+# descriptors (pure)
+# ---------------------------------------------------------------------------
+
+test_that("the two beta modes land on the injected peaks", {
+  set.seed(99L)
+  values <- c(stats::rbeta(4000, 2, 40),    # peak near 0.05
+              stats::rbeta(4000, 40, 2))    # peak near 0.95
+
+  d <- SEMseeker:::.sem_signal_descriptors(values, beta = TRUE)
+
+  expect_lt(d$MODE_LOW, 0.5)
+  expect_gt(d$MODE_HIGH, 0.5)
+  expect_lt(d$MODE_LOW, d$MODE_HIGH)
+  expect_lt(abs(d$MODE_LOW  - 0.05), 0.1)
+  expect_lt(abs(d$MODE_HIGH - 0.95), 0.1)
+  expect_equal(d$N_PROBES, length(values))
+  expect_equal(d$MEDIAN, stats::median(values))
+  expect_equal(d$IQR, stats::IQR(values))
+})
+
+test_that("descriptors omit the modes on the M-value scale", {
+  set.seed(7L)
+  values <- stats::rnorm(1000, mean = 1.5, sd = 2)
+
+  d <- SEMseeker:::.sem_signal_descriptors(values, beta = FALSE)
+
+  expect_null(d$MODE_LOW)
+  expect_null(d$MODE_HIGH)
+  expect_equal(d$MEAN, mean(values))
+  expect_equal(d$VARIANCE, stats::var(values))
+})
+
+test_that("descriptors degrade gracefully on degenerate input", {
+  empty <- SEMseeker:::.sem_signal_descriptors(numeric(0), beta = TRUE)
+  expect_equal(empty$N_PROBES, 0L)
+  expect_true(is.na(empty$MEDIAN))
+
+  # a constant vector has no density to speak of
+  flat <- SEMseeker:::.sem_signal_descriptors(rep(0.5, 100), beta = TRUE)
+  expect_equal(flat$MEDIAN, 0.5)
+  expect_true(is.na(flat$MODE_LOW))
+  expect_true(is.na(flat$MODE_HIGH))
+})
+
+# ---------------------------------------------------------------------------
+# end to end
+# ---------------------------------------------------------------------------
+
+test_that("semseeker() writes the statistics sibling and leaves the sample sheet lean", {
+  tempFolder <- tempFolders[13]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE)
+            unlink(tempFolder, recursive = TRUE) }, add = TRUE)
+
+  syn <- .burden_setup_signal_with_outliers()
+
+  SEMseeker::semseeker(
+    input             = syn$signal,
+    sample_sheet      = syn$samples,
+    result_folder     = tempFolder,
+    parallel_strategy = "sequential",
+    areas             = c("POSITION"),
+    markers           = c("MUTATIONS", "DELTAP", "DELTAS"),
+    start_fresh       = TRUE,
+    inpute            = "median",
+    showprogress      = showprogress,
+    verbosity         = verbosity
+  )
+
+  stats_csv <- file.path(tempFolder, "Data", "SAMPLE_STATS_RESULT.csv")
+  sheet_csv <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
+  expect_true(file.exists(stats_csv))
+  expect_true(file.exists(sheet_csv))
+  skip_if_not(file.exists(stats_csv), "downstream assertions need the sibling")
+
+  stats <- utils::read.csv2(stats_csv, stringsAsFactors = FALSE)
+  sheet <- utils::read.csv2(sheet_csv, stringsAsFactors = FALSE)
+
+  # one row per sample of the signal matrix
+  expect_equal(nrow(stats), ncol(syn$signal))
+
+  descriptor_cols <- c("SAMPLE_MEDIAN", "SAMPLE_MEAN", "SAMPLE_VARIANCE",
+                       "SAMPLE_IQR", "SAMPLE_N_PROBES",
+                       "SAMPLE_MODE_LOW", "SAMPLE_MODE_HIGH")
+  burden_cols <- c("SAMPLE_MUTATIONS_HYPER", "SAMPLE_MUTATIONS_HYPO",
+                   "SAMPLE_DELTAP_HYPER", "SAMPLE_DELTAP_HYPO",
+                   "SAMPLE_DELTAS_HYPER", "SAMPLE_DELTAS_HYPO")
+  expect_true(all(descriptor_cols %in% colnames(stats)),
+              info = paste("missing:",
+                           paste(setdiff(descriptor_cols, colnames(stats)), collapse = ", ")))
+  expect_true(all(burden_cols %in% colnames(stats)),
+              info = paste("missing:",
+                           paste(setdiff(burden_cols, colnames(stats)), collapse = ", ")))
+
+  # the fixture is on the beta scale: descriptors must be in range and the two
+  # modes must sit on either side of 0.5
+  expect_true(all(stats$SAMPLE_MEDIAN >= 0 & stats$SAMPLE_MEDIAN <= 1))
+  expect_true(all(stats$SAMPLE_IQR >= 0))
+  expect_true(all(stats$SAMPLE_N_PROBES > 0))
+  expect_true(all(stats$SAMPLE_MODE_LOW < 0.5, na.rm = TRUE))
+  expect_true(all(stats$SAMPLE_MODE_HIGH >= 0.5, na.rm = TRUE))
+
+  # AI-223 net move: the burden left the sample sheet
+  moved_away <- c("MUTATIONS_HYPER", "MUTATIONS_HYPO", "DELTAS_HYPER",
+                  "DELTAP_HYPER", "PROBES_COUNT")
+  expect_equal(intersect(moved_away, colnames(sheet)), character(0))
+
+  # and the two files join on Sample_ID
+  expect_true(all(sheet$Sample_ID %in% stats$Sample_ID))
+
+  # the join is what consumers see through sem_study_summary_get()
+  SEMseeker:::core_init_env(result_folder = tempFolder, parallel_strategy = "sequential",
+                            areas = c("POSITION"),
+                            markers = c("MUTATIONS", "DELTAP", "DELTAS"),
+                            start_fresh = FALSE, showprogress = FALSE, verbosity = 1)
+  joined <- SEMseeker:::sem_study_summary_get()
+  expect_true(all(burden_cols %in% colnames(joined)))
+  expect_true("SAMPLE_MEDIAN" %in% colnames(joined))
+})

--- a/tests/testthat/test-8-burden-integration.R
+++ b/tests/testthat/test-8-burden-integration.R
@@ -1,9 +1,15 @@
-# AI-086: integration test for sample_sheet_result.csv burden columns.
+# AI-086: integration test for the per-sample burden.
 #
-# Canary for AI-083: sem_study_summary_total() failed to populate per-sample
-# burden in sample_sheet_result.csv on ewas_osteoporosis/GSE99624 (48 samples,
-# 450K) — all burden columns landed as NA, which then crashed every depth=1
-# inference downstream with "data are not the same size".
+# AI-223 moved the burden out of SAMPLE_SHEET_RESULT.csv and into the
+# statistics sibling SAMPLE_STATS_RESULT.csv, where it is named
+# SAMPLE_<MARKER>_<FIGURE> (PROBES_COUNT became SAMPLE_N_PROBES). This test
+# follows it there, and additionally asserts that the sample sheet is left
+# lean.
+#
+# Canary for AI-083: the burden aggregation failed to populate per-sample
+# values on ewas_osteoporosis/GSE99624 (48 samples, 450K) — all burden columns
+# landed as NA, which then crashed every depth=1 inference downstream with
+# "data are not the same size".
 #
 # test-7-association_analysis.R only verifies this indirectly (depth=1 would
 # fail on all-NA burden vectors); this test asserts the contract directly:
@@ -21,47 +27,6 @@
 # DELTAP / DELTARP) plus the two continuous DELTAS / DELTAR. LESIONS depends
 # on MUTATIONS having been computed (SOURCE column), so the full
 # (MUTATIONS + DELTA*) set exercises the whole derive-and-aggregate path.
-
-.burden_setup_signal_with_outliers <- function(seed = 12345L) {
-  set.seed(seed)
-  n_probes_b  <- 200L
-  n_samples_b <- nsamples
-  local_probes  <- probe_features[1:n_probes_b, ]
-  local_samples <- mySampleSheet
-
-  # Background: mostly methylated (Beta(90, 10)).
-  # IMPORTANT: outliers are detected per-probe across samples (IQR × 3 on
-  # the inter-sample distribution). If we inject the SAME band across all
-  # samples uniformly, the per-probe q1/q3 collapse to that uniform value
-  # and IQR → 0 → no sample is flagged. So we inject DISJOINT, RANDOM
-  # per-sample probe sets — each sample is an outlier at probes the other
-  # samples are not, which is exactly the inter-sample dispersion the
-  # threshold needs.
-  local_sig <- matrix(
-    stats::rbeta(n_probes_b * n_samples_b, 90L, 10L),
-    nrow = n_probes_b, ncol = n_samples_b
-  )
-  for (s in seq_len(n_samples_b)) {
-    # 10 random HYPO probes from positions 1:100 → values ≈ 0
-    hypo_probes <- sample.int(100L, 10L)
-    local_sig[hypo_probes, s] <- stats::rbeta(10L, 1L, 100L)
-    # 10 random HYPER probes from positions 101:200 → values ≈ 1
-    hyper_probes <- 100L + sample.int(100L, 10L)
-    local_sig[hyper_probes, s] <- stats::rbeta(10L, 100L, 1L)
-  }
-
-  rownames(local_sig) <- local_probes$PROBE
-  local_sig <- as.data.frame(local_sig)
-  # signal_data has 10 unique columns; mySampleSheet has 16 rows (Reference reuse pattern)
-  colnames(local_sig) <- colnames(signal_data)
-  list(signal = local_sig, samples = local_samples, probes = local_probes)
-}
-
-.burden_required_markers <- c("MUTATIONS",
-                              "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
-                              "DELTAS", "DELTAR")
-.burden_cols <- c(paste0(.burden_required_markers, "_HYPER"),
-                  paste0(.burden_required_markers, "_HYPO"))
 
 test_that("sample_sheet_result.csv has populated burden columns for all discrete + continuous markers (AI-086, canary for AI-083)", {
   tempFolder <- tempFolders[1]
@@ -94,18 +59,27 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
   # by default so either spelling works; Linux ext4 is case-sensitive and
   # only the uppercase form resolves. Use uppercase here to be correct on
   # all three CI runners.
-  result_csv <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
+  result_csv <- file.path(tempFolder, "Data", "SAMPLE_STATS_RESULT.csv")
+  sheet_csv  <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
   testthat::expect_true(
     file.exists(result_csv),
     info = sprintf(
-      "SAMPLE_SHEET_RESULT.csv was not written by semseeker() — tempFolder=%s",
+      "SAMPLE_STATS_RESULT.csv was not written by semseeker() — tempFolder=%s",
       tempFolder
     )
   )
   testthat::skip_if_not(file.exists(result_csv),
-                        "downstream assertions need the result CSV")
+                        "downstream assertions need the statistics sibling")
 
   df <- utils::read.csv2(result_csv, stringsAsFactors = FALSE)
+
+  # AI-223 net move: the sample sheet must NOT carry the burden any more
+  sheet <- utils::read.csv2(sheet_csv, stringsAsFactors = FALSE)
+  testthat::expect_equal(
+    intersect(c("MUTATIONS_HYPER", "MUTATIONS_HYPO", "PROBES_COUNT"),
+              colnames(sheet)),
+    character(0)
+  )
 
   # Required columns: MUTATIONS + DELTA* (LESIONS is optional — derives from
   # MUTATIONS clusters and may legitimately be 0 on small synthetic data.
@@ -113,11 +87,11 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
   required_markers <- c("MUTATIONS",
                         "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
                         "DELTAS", "DELTAR")
-  required_burden_cols <- c(
+  required_burden_cols <- paste0("SAMPLE_", c(
     paste0(required_markers, "_HYPER"),
     paste0(required_markers, "_HYPO")
-  )
-  required_cols <- c("Sample_ID", required_burden_cols, "PROBES_COUNT")
+  ))
+  required_cols <- c("Sample_ID", required_burden_cols, "SAMPLE_N_PROBES")
 
   missing_cols <- setdiff(required_cols, colnames(df))
   testthat::expect_equal(
@@ -127,7 +101,7 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
 
   # Soft: log if LESIONS_HYPER/HYPO are absent so we surface the gap
   # without failing — see AI-088 follow-up for an explicit LESIONS canary.
-  for (lesion_col in c("LESIONS_HYPER", "LESIONS_HYPO")) {
+  for (lesion_col in c("SAMPLE_LESIONS_HYPER", "SAMPLE_LESIONS_HYPO")) {
     if (!(lesion_col %in% colnames(df))) {
       message(sprintf(
         "test-8-burden-integration: %s absent — likely synthetic-data sparsity (soft warn, see AI-088)",
@@ -176,22 +150,22 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
 
   # PROBES_COUNT > 0 on every sample.
   testthat::expect_true(
-    all(df$PROBES_COUNT > 0L, na.rm = TRUE),
-    info = "PROBES_COUNT must be > 0 on every sample"
+    all(df$SAMPLE_N_PROBES > 0L, na.rm = TRUE),
+    info = "SAMPLE_N_PROBES must be > 0 on every sample"
   )
 
   # Sanity: injected HYPO outliers must surface as MUTATIONS_HYPO > 0 on
   # at least the 5 samples we touched (sample indices 1:5).
-  if ("MUTATIONS_HYPO" %in% colnames(df)) {
+  if ("SAMPLE_MUTATIONS_HYPO" %in% colnames(df)) {
     testthat::expect_gt(
-      sum(df$MUTATIONS_HYPO > 0, na.rm = TRUE), 0L,
-      label = "samples with MUTATIONS_HYPO > 0 (injected-outlier sanity)"
+      sum(df$SAMPLE_MUTATIONS_HYPO > 0, na.rm = TRUE), 0L,
+      label = "samples with SAMPLE_MUTATIONS_HYPO > 0 (injected-outlier sanity)"
     )
   }
-  if ("MUTATIONS_HYPER" %in% colnames(df)) {
+  if ("SAMPLE_MUTATIONS_HYPER" %in% colnames(df)) {
     testthat::expect_gt(
-      sum(df$MUTATIONS_HYPER > 0, na.rm = TRUE), 0L,
-      label = "samples with MUTATIONS_HYPER > 0 (injected-outlier sanity)"
+      sum(df$SAMPLE_MUTATIONS_HYPER > 0, na.rm = TRUE), 0L,
+      label = "samples with SAMPLE_MUTATIONS_HYPER > 0 (injected-outlier sanity)"
     )
   }
 
@@ -240,10 +214,10 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
 #       inner merge uses all=TRUE, so a stray object only adds a spurious row),
 #       but the accumulator must be a local binding regardless;
 #   (c) the condition that DOES produce the reported symptom — a burden table
-#       sharing no Sample_ID with the sample sheet. The all.x=TRUE merge then
-#       yields 100% NA burden columns while PROBES_COUNT stays populated, and
-#       every depth=1 inference downstream dies with "data are not the same
-#       size". sem_study_summary_total() must refuse to write that file.
+#       sharing no Sample_ID with the sample sheet, which used to yield 100% NA
+#       burden columns and killed every depth=1 inference downstream with
+#       "data are not the same size". Since AI-223 the aggregation lives in
+#       sem_sample_stats_build(), which must refuse to write that file.
 # ---------------------------------------------------------------------------
 
 test_that("burden survives mixed-case Sample_IDs and a polluted global temp_result (AI-083)", {
@@ -270,7 +244,7 @@ test_that("burden survives mixed-case Sample_IDs and a polluted global temp_resu
   sheet$Sample_ID <- unname(id_map[sheet$Sample_ID])
 
   # (b) pollute globalenv BEFORE the run: the object name collides with the
-  # accumulator inside sem_study_summary_total().
+  # accumulator inside the burden aggregation.
   assign("temp_result",
          data.frame(Sample_ID = "NOT_A_REAL_SAMPLE", JUNK = 1,
                     stringsAsFactors = FALSE),
@@ -291,10 +265,10 @@ test_that("burden survives mixed-case Sample_IDs and a polluted global temp_resu
     verbosity         = verbosity
   )
 
-  result_csv <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
+  result_csv <- file.path(tempFolder, "Data", "SAMPLE_STATS_RESULT.csv")
   testthat::expect_true(file.exists(result_csv))
   testthat::skip_if_not(file.exists(result_csv),
-                        "downstream assertions need the result CSV")
+                        "downstream assertions need the statistics sibling")
 
   df <- utils::read.csv2(result_csv, stringsAsFactors = FALSE)
 
@@ -316,15 +290,18 @@ test_that("burden survives mixed-case Sample_IDs and a polluted global temp_resu
     label = sprintf("mean NA fraction across burden columns (%.2f)",
                     mean(na_fraction))
   )
-  testthat::expect_true(all(df$PROBES_COUNT > 0L, na.rm = TRUE))
+  testthat::expect_true(all(df$SAMPLE_N_PROBES > 0L, na.rm = TRUE))
 
-  # (c) the actual AI-083 signature: rewrite the sample sheet with identifiers
-  # that exist in no pivot, then re-run the aggregation. Before the guard this
-  # silently produced a sample sheet with 100% NA burden; now it must stop and
-  # name both sides.
-  df_broken <- df
-  df_broken$Sample_ID <- paste0("UNRELATED_", seq_len(nrow(df_broken)))
-  utils::write.csv2(df_broken, result_csv, row.names = FALSE)
+  # (c) the actual AI-083 signature: rewrite the SAMPLE SHEET with identifiers
+  # that exist in no pivot, then re-run the aggregation. The producer recomputes
+  # the burden from the pivots (which still carry the real identifiers) and
+  # compares it against the sheet, so corrupting the sheet is what reproduces
+  # the mismatch. Before the guard this silently produced 100% NA burden; now it
+  # must stop and name both sides.
+  sheet_csv <- file.path(tempFolder, "Data", "SAMPLE_SHEET_RESULT.csv")
+  sheet_broken <- utils::read.csv2(sheet_csv, stringsAsFactors = FALSE)
+  sheet_broken$Sample_ID <- paste0("UNRELATED_", seq_len(nrow(sheet_broken)))
+  utils::write.csv2(sheet_broken, sheet_csv, row.names = FALSE)
 
   SEMseeker:::core_init_env(
     result_folder     = tempFolder,
@@ -338,7 +315,7 @@ test_that("burden survives mixed-case Sample_IDs and a polluted global temp_resu
     verbosity         = 1
   )
   testthat::expect_error(
-    SEMseeker:::sem_study_summary_total(),
+    SEMseeker:::sem_sample_stats_build(),
     "no Sample_ID in common"
   )
 })


### PR DESCRIPTION
Stacked on `test/coverage-expansion` (PR #25). Merge that one first.

## Behaviour change (read first)

**The per-sample burden is no longer written to `SAMPLE_SHEET_RESULT.csv`.**
It moved to a new sibling file, `SAMPLE_STATS_RESULT.csv`, where it is named
`SAMPLE_<MARKER>_<FIGURE>`; `PROBES_COUNT` became `SAMPLE_N_PROBES`. The sample
sheet goes back to describing the study. The two files join on `Sample_ID`, and
`sem_study_summary_get()` performs that join, so analyses inside the package are
unaffected. Code outside this repository that read the burden straight from the
sample sheet must read the sibling instead.

Net move with no deprecation window: external adoption is effectively nil
(~30 views / 6 downloads on Zenodo) and the only real consumers are the author's
own pipelines, which are out of scope here.

## What the sibling carries

- burden per marker, `SAMPLE_<MARKER>_<FIGURE>` — summed for discrete markers,
  averaged for continuous ones;
- signal descriptors the sample sheet never had: `SAMPLE_MEDIAN`,
  `SAMPLE_MEAN`, `SAMPLE_VARIANCE`, `SAMPLE_IQR`, `SAMPLE_N_PROBES`;
- on the beta scale only, the two modes of the bimodal distribution:
  `SAMPLE_MODE_LOW` / `SAMPLE_MODE_HIGH`, each the highest density peak on its
  side of 0.5. On M-values the distribution is unimodal and the split would be
  meaningless, so the columns are omitted rather than filled with a
  meaningless number.

Descriptors are computed with the same `foreach %dorng%` idiom used elsewhere,
one sample column collected per worker, so memory is bounded by the number of
workers rather than by the size of the matrix.

## Design points decided while implementing

- The sibling is produced **once with every scope**, not once per depth.
  `depth_analysis` is a consumer-side parameter (`assoc_analysis.R:133`) and
  does not exist at production time, so depth gating is a selection rule on the
  consumer side.
- Column names are composed by a **single shared helper** (`io_scope_name`,
  `io_stat_colname`, `io_burden_colname`) used by producer *and* consumer. Had
  the two sides built the strings independently, the contract would break at the
  first divergence.
- `sem_run_depth1_marker()` renames the SAMPLE-scoped columns back to
  `<MARKER>_<FIGURE>` before the models, so `AREA_OF_TEST` in the inference
  output and the chart file names are unchanged.

Also fixes the depth=1 progress counter, which summed `ncol()` of the whole
sample sheet and therefore counted phenotype columns as if they had been tested.

## Scope

Slice 1 is the `SAMPLE` scope only. Region scopes (`<AREA>[_<SUBAREA>]_*`) are
the next step; the naming already accommodates them.

## Tests

New `test-0-sample-stats-sibling.R` (45 assertions: naming helpers, the two
modes landing on injected peaks, modes absent on the M-value scale, degenerate
input, end-to-end with a lean sample sheet and a working join).
`test-8-burden-integration.R` repointed at the sibling (56), including the
mismatch guard, which now corrupts the sample sheet since that is the side the
producer compares against.

Local before push: `test-0-sample-stats-sibling` 45, `test-8-burden-integration`
56, `test-7-association_analysis` 38, `test-6-semseeker` 98 — 0 failed, 0 error.