### PR TITLE
chore(release): 0.99.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEMseeker
 Type: Package
 Title: Stochastic Epigenetic Mutations SEM Seeker
-Version: 0.99.3
+Version: 0.99.4
 Authors@R: person("Luigi", "Corsaro",
     email = "lcorsaro69@gmail.com",
     role  = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # semseeker NEWS
 
-## semseeker 0.99.3
+## semseeker 0.99.4
 
 ### Breaking changes
 
@@ -50,12 +50,6 @@
 
 ### Documentation
 
-- Aligned the delta-metric documentation in the vignettes and README with the
-  implementation: the `DELTAS`/`DELTAR`/`DELTAP`/`DELTARP`/`DELTAQ`/`DELTARQ`
-  descriptions now reflect the relative-delta ratio and its equal-width and
-  quantile ranked variants. Corrected the pivot file-name examples to
-  `Data/Pivots/<MARKER>/<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<build>.parquet` and
-  updated a stale `enrichment_analysis()` reference.
 - `inst/CITATION` now carries the Zenodo DOI `10.5281/zenodo.5095417` instead
   of a Bioconductor DOI that does not resolve (the package is not on
   Bioconductor yet), and the README no longer says a Zenodo DOI "will be
@@ -90,6 +84,19 @@
   name-based column selection; distinct identifiers that would collapse onto
   the same normalised name, and identifiers without a matching signal column,
   are reported explicitly instead of failing later.
+
+## semseeker 0.99.3
+
+### Documentation
+
+- Aligned the delta-metric documentation in the vignettes and README with the
+  implementation: the `DELTAS`/`DELTAR`/`DELTAP`/`DELTARP`/`DELTAQ`/`DELTARQ`
+  descriptions now reflect the relative-delta ratio and its equal-width and
+  quantile ranked variants. Corrected the pivot file-name examples to
+  `Data/Pivots/<MARKER>/<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<build>.parquet` and
+  updated a stale `enrichment_analysis()` reference.
+
+### Bug fixes
 
 - **`plot_box_plot()`: fixed R CMD check ERROR under ggplot2 >= 4.0.**
   `ggpubr::stat_compare_means(label = "p.format")` builds an internal


### PR DESCRIPTION
Prepares the 0.99.4 release. No package code changes: `NEWS.md` and `DESCRIPTION` only.

## Why

`v0.99.3` was tagged and released on 2026-07-09 from `dd818ee`. Six commits landed on `main` afterwards (#23, #24, #25, #26, #27, #28), and their release notes had been written under the already-published `## semseeker 0.99.3` heading. `release.yaml` extracts the NEWS section matching the version in `DESCRIPTION`, so releasing in that state would have produced notes for a tag that already exists.

## What

- `NEWS.md`: new `## semseeker 0.99.4` section holding the post-tag work; the `0.99.3` section is restored to the exact content it had at the tag (verified byte-identical against `v0.99.3:NEWS.md`).
- `DESCRIPTION`: `0.99.3` to `0.99.4`, staying in the `0.99.x` pre-release series expected for Bioconductor submission.

## Release contents

- **Breaking:** per-sample burden moved from `SAMPLE_SHEET_RESULT.csv` to the new `SAMPLE_STATS_RESULT.csv` sibling (AI-223)
- Per-sample signal descriptors, mode/median/mean/variance/IQR (AI-223)
- Mandatory coverage gate with `coverage_minimum` (AI-074)
- Fixes: empty-result guard on sample-sheet/pivot identifier mismatch (AI-083), non-alphanumeric sample identifiers (AI-224)
- Citation now carries the Zenodo DOI (AI-119)

## After merge

Run `release.yaml` via `workflow_dispatch` to create the `v0.99.4` tag and GitHub Release, then fast-forward `develop`.