### PR TITLE
chore: back-merge 0.99.4 release into develop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEMseeker
 Type: Package
 Title: Stochastic Epigenetic Mutations SEM Seeker
-Version: 0.99.3
+Version: 0.99.4
 Authors@R: person("Luigi", "Corsaro",
     email = "lcorsaro69@gmail.com",
     role  = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # semseeker NEWS
 
-## semseeker 0.99.3
+## semseeker 0.99.4
 
 ### Breaking changes
 
@@ -50,12 +50,6 @@
 
 ### Documentation
 
-- Aligned the delta-metric documentation in the vignettes and README with the
-  implementation: the `DELTAS`/`DELTAR`/`DELTAP`/`DELTARP`/`DELTAQ`/`DELTARQ`
-  descriptions now reflect the relative-delta ratio and its equal-width and
-  quantile ranked variants. Corrected the pivot file-name examples to
-  `Data/Pivots/<MARKER>/<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<build>.parquet` and
-  updated a stale `enrichment_analysis()` reference.
 - `inst/CITATION` now carries the Zenodo DOI `10.5281/zenodo.5095417` instead
   of a Bioconductor DOI that does not resolve (the package is not on
   Bioconductor yet), and the README no longer says a Zenodo DOI "will be
@@ -90,6 +84,19 @@
   name-based column selection; distinct identifiers that would collapse onto
   the same normalised name, and identifiers without a matching signal column,
   are reported explicitly instead of failing later.
+
+## semseeker 0.99.3
+
+### Documentation
+
+- Aligned the delta-metric documentation in the vignettes and README with the
+  implementation: the `DELTAS`/`DELTAR`/`DELTAP`/`DELTARP`/`DELTAQ`/`DELTARQ`
+  descriptions now reflect the relative-delta ratio and its equal-width and
+  quantile ranked variants. Corrected the pivot file-name examples to
+  `Data/Pivots/<MARKER>/<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<build>.parquet` and
+  updated a stale `enrichment_analysis()` reference.
+
+### Bug fixes
 
 - **`plot_box_plot()`: fixed R CMD check ERROR under ggplot2 >= 4.0.**
   `ggpubr::stat_compare_means(label = "p.format")` builds an internal


### PR DESCRIPTION
Brings the `0.99.4` release commit (NEWS split + version bump, #29) back into `develop` so the working branch matches `main` after the release.

Direct pushes to `develop` are now blocked by branch protection, so the fast-forward goes through this PR. No code changes.