### PR TITLE
refactor(ai-223): one file per helper, single source of truth for stat names

### DIFF
--- a/R/io_burden_colname.R
+++ b/R/io_burden_colname.R
@@ -1,0 +1,15 @@
+#' Compose a per-marker burden column name of the sibling artefact
+#'
+#' `<SCOPE>_<MARKER>_<FIGURE>`, e.g. `SAMPLE_MUTATIONS_HYPER`. See
+#' [io_scope_name()] for the naming contract this belongs to.
+#'
+#' @param scope scope name, as returned by [io_scope_name()].
+#' @param marker marker name.
+#' @param figure figure name (`HYPER` / `HYPO`).
+#' @keywords internal
+#' @noRd
+io_burden_colname <- function(scope, marker, figure) {
+  if (missing(scope) || is.null(scope) || !nzchar(scope))
+    stop("io_burden_colname(): 'scope' is required (use io_scope_name()).")
+  core_name_cleaning(paste(scope, marker, figure, sep = "_"))
+}

--- a/R/io_scope_name.R
+++ b/R/io_scope_name.R
@@ -1,0 +1,36 @@
+#' Column names of the per-sample statistics sibling (internal)
+#'
+#' AI-223. The sibling artefact (`SAMPLE_STATS_RESULT.csv`) is the contract
+#' between production (annotation + aggregation, inside `semseeker()`) and
+#' consumption (`association_analysis()`). Both sides MUST compose its column
+#' names through these helpers: if producer and consumer built the strings
+#' independently, the contract would break at the first divergence.
+#'
+#' Naming, all uppercase via [core_name_cleaning()]:
+#' \itemize{
+#'   \item scope — `SAMPLE` (whole sample, no genomic filter), `<AREA>`, or
+#'     `<AREA>_<SUBAREA>`;
+#'   \item signal descriptors (marker-independent) — `<SCOPE>_<STAT>`, e.g.
+#'     `SAMPLE_MEDIAN`, `GENE_BODY_IQR`, composed by [io_stat_colname()];
+#'   \item burden per marker — `<SCOPE>_<MARKER>_<FIGURE>`, e.g.
+#'     `SAMPLE_MUTATIONS_HYPER`, composed by [io_burden_colname()].
+#' }
+#'
+#' The set of statistics a scope carries is declared by [io_signal_stats()] and
+#' computed by [util_signal_descriptors()].
+#'
+#' @keywords internal
+#' @noRd
+io_scope_name <- function(depth = 1L, area = NULL, subarea = NULL) {
+  depth <- suppressWarnings(as.integer(depth))
+  if (length(depth) != 1L || is.na(depth)) depth <- 1L
+
+  if (depth <= 1L || is.null(area) || !nzchar(as.character(area)))
+    return("SAMPLE")
+
+  parts <- as.character(area)
+  if (depth >= 3L && !is.null(subarea) && nzchar(as.character(subarea)))
+    parts <- c(parts, as.character(subarea))
+
+  core_name_cleaning(paste(parts, collapse = "_"))
+}

--- a/R/io_signal_stats.R
+++ b/R/io_signal_stats.R
@@ -1,0 +1,20 @@
+#' Statistics emitted for a signal scope
+#'
+#' Single source of truth for which statistics a scope carries: the producer
+#' composes the column names from this vector via [io_stat_colname()], and
+#' [util_signal_descriptors()] builds its output on it, so the computed keys and
+#' the declared vocabulary cannot drift apart.
+#'
+#' MODE_LOW / MODE_HIGH only make sense on a bounded, bimodal scale (beta in
+#' [0,1], the two peaks around 0 and 1). On M-values the distribution is
+#' roughly gaussian and the two-mode split carries no meaning, so the columns
+#' are omitted rather than filled with a meaningless number.
+#'
+#' @param beta logical. TRUE when the signal is on the [0,1] beta scale.
+#' @return character vector of statistic names.
+#' @keywords internal
+#' @noRd
+io_signal_stats <- function(beta = TRUE) {
+  base <- c("MEDIAN", "MEAN", "VARIANCE", "IQR", "N_PROBES")
+  if (isTRUE(beta)) c(base, "MODE_LOW", "MODE_HIGH") else base
+}

--- a/R/io_stat_colname.R
+++ b/R/io_stat_colname.R
@@ -1,63 +1,14 @@
-#' Column names of the per-sample statistics sibling (internal)
+#' Compose a signal-descriptor column name of the sibling artefact
 #'
-#' AI-223. The sibling artefact (`SAMPLE_STATS_RESULT.csv`) is the contract
-#' between production (annotation + aggregation, inside `semseeker()`) and
-#' consumption (`association_analysis()`). Both sides MUST compose its column
-#' names through these helpers: if producer and consumer built the strings
-#' independently, the contract would break at the first divergence.
+#' `<SCOPE>_<STAT>`, e.g. `SAMPLE_MEDIAN` or `GENE_BODY_IQR`. See
+#' [io_scope_name()] for the naming contract this belongs to.
 #'
-#' Naming, all uppercase via [core_name_cleaning()]:
-#' \itemize{
-#'   \item scope — `SAMPLE` (whole sample, no genomic filter), `<AREA>`, or
-#'     `<AREA>_<SUBAREA>`;
-#'   \item signal descriptors (marker-independent) — `<SCOPE>_<STAT>`, e.g.
-#'     `SAMPLE_MEDIAN`, `GENE_BODY_IQR`;
-#'   \item burden per marker — `<SCOPE>_<MARKER>_<FIGURE>`, e.g.
-#'     `SAMPLE_MUTATIONS_HYPER`.
-#' }
-#'
-#' @keywords internal
-#' @noRd
-io_scope_name <- function(depth = 1L, area = NULL, subarea = NULL) {
-  depth <- suppressWarnings(as.integer(depth))
-  if (length(depth) != 1L || is.na(depth)) depth <- 1L
-
-  if (depth <= 1L || is.null(area) || !nzchar(as.character(area)))
-    return("SAMPLE")
-
-  parts <- as.character(area)
-  if (depth >= 3L && !is.null(subarea) && nzchar(as.character(subarea)))
-    parts <- c(parts, as.character(subarea))
-
-  core_name_cleaning(paste(parts, collapse = "_"))
-}
-
+#' @param scope scope name, as returned by [io_scope_name()].
+#' @param stat one of the statistics declared by [io_signal_stats()].
 #' @keywords internal
 #' @noRd
 io_stat_colname <- function(scope, stat) {
   if (missing(scope) || is.null(scope) || !nzchar(scope))
     stop("io_stat_colname(): 'scope' is required (use io_scope_name()).")
   core_name_cleaning(paste(scope, stat, sep = "_"))
-}
-
-#' @keywords internal
-#' @noRd
-io_burden_colname <- function(scope, marker, figure) {
-  if (missing(scope) || is.null(scope) || !nzchar(scope))
-    stop("io_burden_colname(): 'scope' is required (use io_scope_name()).")
-  core_name_cleaning(paste(scope, marker, figure, sep = "_"))
-}
-
-#' Statistics emitted for a signal scope
-#'
-#' MODE_LOW / MODE_HIGH only make sense on a bounded, bimodal scale (beta in
-#' [0,1], the two peaks around 0 and 1). On M-values the distribution is
-#' roughly gaussian and the two-mode split carries no meaning, so the columns
-#' are omitted rather than filled with a meaningless number.
-#'
-#' @keywords internal
-#' @noRd
-io_signal_stats <- function(beta = TRUE) {
-  base <- c("MEDIAN", "MEAN", "VARIANCE", "IQR", "N_PROBES")
-  if (isTRUE(beta)) c(base, "MODE_LOW", "MODE_HIGH") else base
 }

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -185,7 +185,7 @@ sem_sample_stats_build <- function() {
     values <- as.numeric(values)
     values <- values[is.finite(values)]
 
-    row <- SEMseeker:::.sem_signal_descriptors(values, beta = beta)
+    row <- SEMseeker:::util_signal_descriptors(values, beta = beta)
     out <- data.frame(Sample_ID = sample_id, stringsAsFactors = FALSE)
     for (i in seq_along(stats_wanted)) {
       # NULL would DROP the column instead of filling it, and rows of unequal
@@ -203,58 +203,4 @@ sem_sample_stats_build <- function() {
 
   rownames(descriptors) <- NULL
   descriptors
-}
-
-#' Reduce one sample's signal vector to its descriptors
-#'
-#' Split at 0.5 for the two beta modes: methylation beta values are bimodal
-#' with peaks near 0 (unmethylated) and near 1 (methylated), so the highest
-#' density peak on each side of 0.5 is the natural estimate of each mode. On
-#' M-values the distribution is unimodal and the split is meaningless, which is
-#' why [io_signal_stats()] does not request the mode columns there.
-#'
-#' @param values numeric vector, already filtered to finite values.
-#' @param beta logical. TRUE when the signal is on the [0,1] beta scale.
-#' @return named list of statistics.
-#' @keywords internal
-#' @noRd
-.sem_signal_descriptors <- function(values, beta = TRUE) {
-
-  out <- list(
-    MEDIAN     = NA_real_,
-    MEAN       = NA_real_,
-    VARIANCE   = NA_real_,
-    IQR        = NA_real_,
-    N_PROBES   = length(values)
-  )
-
-  if (length(values) == 0)
-    return(out)
-
-  out$MEDIAN   <- stats::median(values)
-  out$MEAN     <- mean(values)
-  out$VARIANCE <- stats::var(values)
-  out$IQR      <- stats::IQR(values)
-
-  if (!isTRUE(beta))
-    return(out)
-
-  out$MODE_LOW  <- NA_real_
-  out$MODE_HIGH <- NA_real_
-  # density() needs at least two distinct points to estimate anything.
-  if (length(unique(values)) < 2L)
-    return(out)
-
-  dens <- tryCatch(stats::density(values, from = 0, to = 1),
-                   error = function(e) NULL)
-  if (is.null(dens))
-    return(out)
-
-  low <- dens$x < 0.5
-  if (any(low))
-    out$MODE_LOW <- dens$x[low][which.max(dens$y[low])]
-  if (any(!low))
-    out$MODE_HIGH <- dens$x[!low][which.max(dens$y[!low])]
-
-  out
 }

--- a/R/util_signal_descriptors.R
+++ b/R/util_signal_descriptors.R
@@ -1,0 +1,60 @@
+#' Reduce one sample's signal vector to its descriptors
+#'
+#' Generic descriptive statistics on a numeric vector: no SEM domain knowledge,
+#' no I/O. Slice 1 of AI-223 calls it once per sample on the whole probe set
+#' (scope `SAMPLE`); the region scopes reuse it unchanged on the subset of
+#' probes of an area/subarea.
+#'
+#' The returned keys are built from [io_signal_stats()] rather than written out
+#' here, so the computed statistics and the vocabulary declared to the consumer
+#' cannot diverge. A statistic this function does not fill stays `NA`.
+#'
+#' Split at 0.5 for the two beta modes: methylation beta values are bimodal
+#' with peaks near 0 (unmethylated) and near 1 (methylated), so the highest
+#' density peak on each side of 0.5 is the natural estimate of each mode. On
+#' M-values the distribution is unimodal and the split is meaningless, which is
+#' why [io_signal_stats()] does not declare the mode columns there.
+#'
+#' @param values numeric vector, already filtered to finite values.
+#' @param beta logical. TRUE when the signal is on the [0,1] beta scale.
+#' @return named list of statistics, one element per [io_signal_stats()] entry.
+#' @keywords internal
+#' @noRd
+util_signal_descriptors <- function(values, beta = TRUE) {
+
+  wanted <- io_signal_stats(beta)
+  out    <- stats::setNames(vector("list", length(wanted)), wanted)
+  out[]  <- NA_real_
+
+  out$N_PROBES <- length(values)
+
+  if (length(values) == 0)
+    return(out)
+
+  out$MEDIAN   <- stats::median(values)
+  out$MEAN     <- mean(values)
+  out$VARIANCE <- stats::var(values)
+  out$IQR      <- stats::IQR(values)
+
+  # Off the beta scale the modes are not part of the vocabulary at all, so
+  # there is nothing left to estimate.
+  if (!all(c("MODE_LOW", "MODE_HIGH") %in% wanted))
+    return(out)
+
+  # density() needs at least two distinct points to estimate anything.
+  if (length(unique(values)) < 2L)
+    return(out)
+
+  dens <- tryCatch(stats::density(values, from = 0, to = 1),
+                   error = function(e) NULL)
+  if (is.null(dens))
+    return(out)
+
+  low <- dens$x < 0.5
+  if (any(low))
+    out$MODE_LOW <- dens$x[low][which.max(dens$y[low])]
+  if (any(!low))
+    out$MODE_HIGH <- dens$x[!low][which.max(dens$y[!low])]
+
+  out
+}

--- a/tests/testthat/test-0-sample-stats-sibling.R
+++ b/tests/testthat/test-0-sample-stats-sibling.R
@@ -55,7 +55,7 @@ test_that("the two beta modes land on the injected peaks", {
   values <- c(stats::rbeta(4000, 2, 40),    # peak near 0.05
               stats::rbeta(4000, 40, 2))    # peak near 0.95
 
-  d <- SEMseeker:::.sem_signal_descriptors(values, beta = TRUE)
+  d <- SEMseeker:::util_signal_descriptors(values, beta = TRUE)
 
   expect_lt(d$MODE_LOW, 0.5)
   expect_gt(d$MODE_HIGH, 0.5)
@@ -71,7 +71,7 @@ test_that("descriptors omit the modes on the M-value scale", {
   set.seed(7L)
   values <- stats::rnorm(1000, mean = 1.5, sd = 2)
 
-  d <- SEMseeker:::.sem_signal_descriptors(values, beta = FALSE)
+  d <- SEMseeker:::util_signal_descriptors(values, beta = FALSE)
 
   expect_null(d$MODE_LOW)
   expect_null(d$MODE_HIGH)
@@ -80,12 +80,12 @@ test_that("descriptors omit the modes on the M-value scale", {
 })
 
 test_that("descriptors degrade gracefully on degenerate input", {
-  empty <- SEMseeker:::.sem_signal_descriptors(numeric(0), beta = TRUE)
+  empty <- SEMseeker:::util_signal_descriptors(numeric(0), beta = TRUE)
   expect_equal(empty$N_PROBES, 0L)
   expect_true(is.na(empty$MEDIAN))
 
   # a constant vector has no density to speak of
-  flat <- SEMseeker:::.sem_signal_descriptors(rep(0.5, 100), beta = TRUE)
+  flat <- SEMseeker:::util_signal_descriptors(rep(0.5, 100), beta = TRUE)
   expect_equal(flat$MEDIAN, 0.5)
   expect_true(is.na(flat$MODE_LOW))
   expect_true(is.na(flat$MODE_HIGH))


### PR DESCRIPTION
Groundwork for slice 2 of AI-223 (region scopes). No behaviour change in the written artefact.

## Why

`io_stat_colname.R` held four functions and was named after only one of them, and the descriptor maths sat as a file-private `.sem_signal_descriptors()` inside the sample-level producer. Slice 2 has to reuse that maths on the probe subset of an area/subarea, so leaving it dot-prefixed and buried in the producer would have contradicted the convention the rest of `R/` follows — 157 single-function files against 31 multi-function ones.

## What

| file | contents |
|---|---|
| `R/io_scope_name.R` | `io_scope_name()` + the naming-contract docblock |
| `R/io_stat_colname.R` | `io_stat_colname()` only |
| `R/io_burden_colname.R` | `io_burden_colname()` |
| `R/io_signal_stats.R` | `io_signal_stats()` |
| `R/util_signal_descriptors.R` | the maths, no dot prefix |

`.sem_signal_descriptors()` becomes `util_signal_descriptors()`: it is generic descriptive statistics on a numeric vector, with no SEM knowledge and no I/O, so `util_` describes it better than `sem_`. The `SEMseeker:::` qualifier at the `foreach` call site is preserved — the worker needs it to resolve the internal function.

## Latent drift closed

`util_signal_descriptors()` now builds its output keys from `io_signal_stats(beta)` instead of writing `MEDIAN`/`MEAN`/... out a second time. Previously the computation and the declared vocabulary were two independent lists of the same strings; a divergence would have silently produced an all-`NA` column, since the consumer fills missing keys with `NA`.

Only visible consequence: on an empty vector on the beta scale the result now carries `MODE_LOW`/`MODE_HIGH` as `NA` instead of omitting them, which is what the declared vocabulary asks for. The written CSV is unchanged.

## Tests

Local, macOS: `test-0-sample-stats-sibling` 45 pass / 0 fail, `test-8-burden-integration` 56 pass / 0 fail. No `Collate` field in DESCRIPTION, so the new files need no load-order bookkeeping.