### PR TITLE
feat(sample-stats): region scope for the per-sample burden, consumed at depth 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # semseeker NEWS
 
+## semseeker 0.99.5 (development)
+
+### New features
+
+- **Per-sample burden restricted to a region class (AI-223 slice 2a).** The
+  statistics sibling can now carry a scope other than the whole sample:
+  `semseeker(sample_stats_scopes = c("SAMPLE", "GENE_TSS1500"))` adds
+  `GENE_TSS1500_<MARKER>_<FIGURE>`, the burden computed over the probes of that
+  region class only. Any registered `(AREA, SUBAREA)` pair of the run is a
+  legal scope; `SAMPLE` is always produced. A scope that does not resolve stops
+  the run instead of being ignored.
+
+  Each position is counted **once**, even when the annotation maps it to
+  several genes. The burden is computed from the POSITION pivot restricted to
+  the probes of the region, not by summing the per-gene pivot — summing the
+  latter would count a multi-gene probe once per gene.
+
+- **Region scopes as dependent variable at `depth = 1`.** The new
+  `inference_details$scopes` column (several separated by `"+"`, default
+  `"SAMPLE"`) selects which scopes `association_analysis()` tests at depth 1.
+  A region scope is still one value per sample, so its rows keep `DEPTH = 1`
+  and `SUBAREA = "SAMPLE"`, with the scope in `AREA` (e.g. `GENE_TSS1500`) and
+  `AREA_OF_TEST` unchanged. Requesting a scope that was never produced is an
+  error naming the scope, not a silently empty result.
+
 ## semseeker 0.99.4
 
 ### Breaking changes

--- a/R/assoc_analysis.R
+++ b/R/assoc_analysis.R
@@ -25,6 +25,14 @@
 #'     \item{depth_analysis}{Integer depth: \code{1} = sample level,
 #'       \code{2} = type level (gene, DMR, CpG island),
 #'       \code{3} = genomic area (TSS1550, WHOLE, TSS200, …).}
+#'     \item{scopes}{Optional, depth=1 only. Which scopes of
+#'       \code{SAMPLE_STATS_RESULT.csv} to test, several separated by
+#'       \code{"+"} (default \code{"SAMPLE"}). A region scope such as
+#'       \code{"GENE_TSS1500"} tests the burden restricted to that region
+#'       class, still one value per sample: the result rows carry
+#'       \code{DEPTH = 1} with \code{AREA = "GENE_TSS1500"}. The scope must
+#'       have been produced by
+#'       \code{semseeker(sample_stats_scopes = ...)}, otherwise the run stops.}
 #'   }
 #' @param result_folder character. Path to the SEMseeker result folder.
 #' @param maxResources numeric. Maximum percentage of CPU cores to use

--- a/R/assoc_validate_inference_schema.R
+++ b/R/assoc_validate_inference_schema.R
@@ -36,6 +36,10 @@ assoc_validate_inference_schema <- function(inference_details, strict = TRUE) {
     "transformation_y",
     "transformation_x",
     "depth_analysis",
+    # AI-223 slice 2a: scopes tested at depth=1, as they are named in the
+    # statistics sibling ("SAMPLE", "GENE_TSS1500", …). Several are given
+    # separated by "+", like covariates. Default "SAMPLE".
+    "scopes",
     "filter_p_value",
     "samples_sql_condition",
     "areas_sql_condition",

--- a/R/core_init_env.R
+++ b/R/core_init_env.R
@@ -35,6 +35,7 @@
   showprogress           = list(value = FALSE),
   openai_api_key         = list(value = ""),
   multiple_test_adj      = list(value = "q", choices = c("BY","fdr","BH","bonferroni","q")),
+  sample_stats_scopes    = list(value = "SAMPLE"), # AI-223 slice 2a: scopes of the per-sample statistics sibling. "SAMPLE" (whole sample, always produced) plus any registered AREA_SUBAREA pair, e.g. "GENE_TSS1500".
   coverage_minimum       = list(value = 80),      # AI-074: minimum % of input positions that must be present in the reference annotation; below it sem_coverage_gate() stops the run.
   bulk_population        = list(value = TRUE)    # AI-042: vectorized population is the default (no per-sample bed dump). Set FALSE only to core_recover the legacy per-sample loop.
 )

--- a/R/io_scope_name.R
+++ b/R/io_scope_name.R
@@ -19,9 +19,26 @@
 #' The set of statistics a scope carries is declared by [io_signal_stats()] and
 #' computed by [util_signal_descriptors()].
 #'
+#' @section Depth-free entry (AI-223 slice 2a):
+#' The producer is depth-agnostic by design — the sibling is written ONCE with
+#' every requested scope, not once per depth. Called with `depth = NULL` (e.g.
+#' `io_scope_name(area = "GENE", subarea = "TSS1500")`) the scope is derived
+#' from the pair alone: no area means `SAMPLE`, otherwise `<AREA>[_<SUBAREA>]`.
+#' The depth-driven form is what the depth=2/3 consumers still use.
+#'
 #' @keywords internal
 #' @noRd
-io_scope_name <- function(depth = 1L, area = NULL, subarea = NULL) {
+io_scope_name <- function(depth = NULL, area = NULL, subarea = NULL) {
+
+  if (is.null(depth)) {
+    if (is.null(area) || !nzchar(as.character(area)))
+      return("SAMPLE")
+    parts <- as.character(area)
+    if (!is.null(subarea) && nzchar(as.character(subarea)))
+      parts <- c(parts, as.character(subarea))
+    return(core_name_cleaning(paste(parts, collapse = "_")))
+  }
+
   depth <- suppressWarnings(as.integer(depth))
   if (length(depth) != 1L || is.na(depth)) depth <- 1L
 

--- a/R/sem_run_depth1_marker.R
+++ b/R/sem_run_depth1_marker.R
@@ -22,47 +22,72 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   processed_items <- 0L
 
   # AI-223: the sample-level burden lives in the statistics sibling, joined
-  # onto study_summary by sem_study_summary_get() under the SAMPLE scope. Its
-  # column names are composed with the shared helper — never hard-coded — and
-  # renamed back to <MARKER>_<FIGURE> below so the inference output (AREA_OF_TEST)
-  # keeps its historical values.
-  cols        <- keys$COMBINED
-  burden_cols <- io_burden_colname("SAMPLE", keys$MARKER, keys$FIGURE)
-  present     <- burden_cols %in% colnames(prep$study_summary)
-  if (sum(present) == 0)
-    return(list(results = results, processed_items = processed_items))
+  # onto study_summary by sem_study_summary_get(). Its column names are
+  # composed with the shared helper — never hard-coded — and renamed back to
+  # <MARKER>_<FIGURE> below so the inference output (AREA_OF_TEST) keeps its
+  # historical values.
+  # AI-223 slice 2a: the same test can run on a region scope of the sibling
+  # (e.g. GENE_TSS1500 = burden restricted to the probes of that region class).
+  # It is still one value per sample, hence still DEPTH=1; the scope is what
+  # the AREA column carries.
+  scopes <- .sem_depth1_scopes_get(prep, ssEnv)
 
-  keys        <- keys[present, , drop = FALSE]
-  cols        <- cols[present]
-  burden_cols <- burden_cols[present]
-  prep$study_summary <- .sem_burden_cols_rename(prep$study_summary, burden_cols, cols)
-  keys$AREA     <- "SAMPLE_GROUP"
-  keys$SUBAREA  <- "SAMPLE"
-
-  has_covariates <- !is.null(prep$covariates) && length(prep$covariates) != 0
-  if (has_covariates) {
-    study_summary_local <- prep$study_summary[,
-      c(prep$independent_variable, prep$covariates, cols, "Sample_Group")]
-  } else {
-    study_summary_local <- prep$study_summary
-  }
-
-  # resume: drop keys already present in the CSV (DEPTH==1 only)
+  # resume: drop keys already present in the CSV (DEPTH==1 only). Read once,
+  # the scope is part of the identity through AREA.
   file_good <- file.exists(fileNameResults) && file.info(fileNameResults)$size > 3
   old_results <- data.frame()
+  done_ids <- character(0)
   if (file_good) {
     old_results <- unique(utils::read.csv2(fileNameResults, header = TRUE))
     old_filtered <- old_results[old_results$DEPTH == 1, ]
     done_ids <- unlist(apply(unique(old_filtered[, c("MARKER", "FIGURE", "AREA", "SUBAREA")]), 1,
       function(x) paste(x, collapse = "_", sep = "")))
-    todo_ids <- unlist(apply(keys[, c("MARKER", "FIGURE", "AREA", "SUBAREA")], 1,
-      function(x) paste(x, collapse = "_", sep = "")))
-    keys <- keys[!(todo_ids %in% done_ids), ]
   }
 
-  if (nrow(keys) > 0) {
-    for (j in seq_len(nrow(keys))) {
-      key <- keys[j, ]
+  any_scope_ran <- FALSE
+  for (scope in scopes) {
+    scope_keys  <- keys
+    cols        <- scope_keys$COMBINED
+    burden_cols <- io_burden_colname(scope, scope_keys$MARKER, scope_keys$FIGURE)
+    present     <- burden_cols %in% colnames(prep$study_summary)
+    if (sum(present) == 0) {
+      if (!identical(scope, "SAMPLE"))
+        core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+          " Scope ", scope, " carries no burden column for this marker; skipped.")
+      next
+    }
+
+    any_scope_ran <- TRUE
+    scope_keys  <- scope_keys[present, , drop = FALSE]
+    cols        <- cols[present]
+    burden_cols <- burden_cols[present]
+    # The renaming is per scope and starts from the untouched study_summary:
+    # two scopes would otherwise fight over the same <MARKER>_<FIGURE> name.
+    study_summary_scope <- .sem_burden_cols_rename(prep$study_summary, burden_cols, cols)
+    # SUBAREA == "SAMPLE" is what makes assoc_analysis_save_results() stamp
+    # DEPTH = 1; AREA says which scope was aggregated.
+    scope_keys$AREA    <- if (identical(scope, "SAMPLE")) "SAMPLE_GROUP" else scope
+    scope_keys$SUBAREA <- "SAMPLE"
+
+    has_covariates <- !is.null(prep$covariates) && length(prep$covariates) != 0
+    if (has_covariates) {
+      study_summary_local <- study_summary_scope[,
+        c(prep$independent_variable, prep$covariates, cols, "Sample_Group")]
+    } else {
+      study_summary_local <- study_summary_scope
+    }
+
+    if (length(done_ids) > 0) {
+      todo_ids <- unlist(apply(scope_keys[, c("MARKER", "FIGURE", "AREA", "SUBAREA")], 1,
+        function(x) paste(x, collapse = "_", sep = "")))
+      scope_keys <- scope_keys[!(todo_ids %in% done_ids), ]
+    }
+
+    if (nrow(scope_keys) == 0)
+      next
+
+    for (j in seq_len(nrow(scope_keys))) {
+      key <- scope_keys[j, ]
       key$FIGURE <- as.character(key$FIGURE)
       key$MARKER <- as.character(key$MARKER)
       g_start <- 2 + length(prep$covariates)
@@ -100,6 +125,11 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
     }
   }
 
+  # Nothing of this marker is present in the sibling (e.g. a result folder
+  # produced before AI-223): leave the CSV exactly as it was found.
+  if (!any_scope_ran)
+    return(list(results = data.frame(), processed_items = processed_items))
+
   if (!is.null(dim(results)) && nrow(results) > 0 && "PVALUE_ADJ" %in% colnames(results))
     results <- results[order(results$PVALUE_ADJ), ]
 
@@ -114,6 +144,44 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   assoc_analysis_save_results(results, fileNameResults, family_test, filter_p_value)
 
   list(results = results, processed_items = processed_items)
+}
+
+#' Scopes to test at depth=1, validated against the statistics sibling
+#'
+#' AI-223 slice 2a. `inference_details$scopes` names them the way the sibling
+#' names its columns (`SAMPLE`, `GENE_TSS1500`, …), several separated by `"+"`
+#' like covariates. Default `SAMPLE`, which is the historical behaviour.
+#'
+#' A requested scope whose columns are absent from the sibling is an error, not
+#' a skip: the run would otherwise produce a complete-looking inference CSV
+#' that simply never tested what was asked. The producer side of the contract
+#' is `semseeker(sample_stats_scopes = ...)`.
+#'
+#' @keywords internal
+#' @noRd
+.sem_depth1_scopes_get <- function(prep, ssEnv) {
+
+  requested <- prep$inference_detail$scopes
+  if (is.null(requested) || length(requested) == 0 || all(is.na(requested)))
+    return("SAMPLE")
+  requested <- util_split_and_clean(requested)
+  requested <- core_name_cleaning(requested[nzchar(requested)])
+  if (length(requested) == 0)
+    return("SAMPLE")
+
+  # Every marker/figure the run knows about — the sibling carries a column per
+  # pair and per scope, so one hit is enough to say the scope was produced.
+  all_keys <- ssEnv$keys_markers_figures
+  known_cols <- colnames(prep$study_summary)
+  for (scope in requested) {
+    candidates <- io_burden_colname(scope, all_keys$MARKER, all_keys$FIGURE)
+    if (!any(candidates %in% known_cols))
+      stop("inference_details$scopes: scope '", scope, "' has no column in ",
+           "SAMPLE_STATS_RESULT. Produce it with ",
+           "semseeker(sample_stats_scopes = c(\"SAMPLE\", \"", scope, "\")) ",
+           "and rerun the analysis.")
+  }
+  unique(requested)
 }
 
 #' Rename the SAMPLE-scope burden columns back to <MARKER>_<FIGURE>

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -16,9 +16,13 @@
 #'
 #' Keeping these out of the sample sheet is deliberate: the sheet stays the
 #' description of the study, this file carries what the run computed, and the
-#' two join on `Sample_ID`. Region scopes (`<AREA>[_<SUBAREA>]_*`) are the next
-#' slice; the column naming already accommodates them through
-#' [io_scope_name()].
+#' two join on `Sample_ID`.
+#'
+#' AI-223 slice 2a — region scopes. `sample_stats_scopes` (a `semseeker()`
+#' argument, default `"SAMPLE"`) adds the burden restricted to one registered
+#' `(AREA, SUBAREA)` pair, e.g. `"GENE_TSS1500"` produces
+#' `GENE_TSS1500_<MARKER>_<FIGURE>`. The `SAMPLE` scope is always produced,
+#' whatever the argument says: the depth=1 consumer relies on it.
 #'
 #' @return Invisibly the path of the file written, or `NULL` when there was
 #'   nothing to write.
@@ -29,7 +33,22 @@ sem_sample_stats_build <- function() {
 
   ssEnv <- core_get_session_info()
 
-  burden      <- .sem_sample_burden_get()
+  burden <- NULL
+  scopes <- .sem_stats_scopes_get()
+  core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
+            " Per-sample statistics, scopes: ",
+            paste(vapply(scopes, function(s) s$scope, character(1)), collapse = ", "), ".")
+  for (scope in scopes) {
+    scope_burden <- .sem_sample_burden_get(scope$area, scope$subarea)
+    if (is.null(scope_burden))
+      next
+    burden <- if (is.null(burden)) scope_burden else
+      merge(burden, scope_burden, by = "Sample_ID", all = TRUE)
+  }
+
+  # Signal descriptors stay at sample level: the region-scoped descriptors are
+  # a separate decision (they are not marker/figure pairs, so they do not
+  # travel through the keys machinery the way the burden does).
   descriptors <- .sem_sample_descriptors_get()
 
   if (is.null(burden) && is.null(descriptors)) {
@@ -77,21 +96,137 @@ sem_sample_stats_build <- function() {
   invisible(file_path)
 }
 
-#' Burden per marker at sample level
+#' Scopes the sibling must carry, resolved against the keys of the run
+#'
+#' AI-223 slice 2a. `ssEnv$sample_stats_scopes` names scopes the way they
+#' appear in the column prefixes (`SAMPLE`, `GENE_TSS1500`, …); this resolves
+#' each one back to the `(AREA, SUBAREA)` pair that defines it, using
+#' `ssEnv$keys_areas_subareas$COMBINED` as the registry.
+#'
+#' A scope that does not resolve is an error, not a silent drop: a run that
+#' quietly ignores the argument would look identical to one that honoured it,
+#' and the researcher would only find out when the column is missing at
+#' analysis time.
+#'
+#' @return list of `list(scope, area, subarea)`, `SAMPLE` always first.
+#' @keywords internal
+#' @noRd
+.sem_stats_scopes_get <- function() {
+
+  ssEnv <- core_get_session_info()
+  requested <- ssEnv$sample_stats_scopes
+  if (is.null(requested) || length(requested) == 0)
+    requested <- "SAMPLE"
+  # SAMPLE is not optional: the depth=1 consumer and the historical burden
+  # columns both live there.
+  requested <- unique(c("SAMPLE", core_name_cleaning(as.character(requested))))
+
+  registry <- ssEnv$keys_areas_subareas
+  available <- if (is.null(registry) || !("COMBINED" %in% colnames(registry)))
+    character(0) else core_name_cleaning(as.character(registry$COMBINED))
+
+  scopes <- list()
+  for (name in requested) {
+    if (identical(name, "SAMPLE")) {
+      scopes[[length(scopes) + 1L]] <- list(scope = "SAMPLE", area = NULL, subarea = NULL)
+      next
+    }
+    idx <- which(available == name)
+    if (length(idx) == 0)
+      stop("sample_stats_scopes: unknown scope '", name,
+           "'. A scope is an (AREA, SUBAREA) pair of this run. Available: ",
+           paste(c("SAMPLE", available), collapse = ", "), ".")
+    scopes[[length(scopes) + 1L]] <- list(
+      scope   = name,
+      area    = as.character(registry$AREA[idx[1]]),
+      subarea = as.character(registry$SUBAREA[idx[1]]))
+  }
+  scopes
+}
+
+#' Probe mask of a region scope
+#'
+#' The set of positions that belong to the scope, one row per position. Built
+#' from [anno_probe_features_get()] — the same annotation the pivots use — and
+#' deliberately NOT from the annotated `<AREA>/<SUBAREA>` pivot: annotation
+#' explodes probes that map to several genes, so summing that pivot would count
+#' a probe once per gene. Restricting the POSITION pivot to this mask counts
+#' every position exactly once, which is what a per-sample burden restricted to
+#' a region class means.
+#'
+#' @return a lazy polars frame with CHR/START/END normalised the way the
+#'   POSITION pivot stores them, or `NULL` when the scope selects nothing.
+#' @keywords internal
+#' @noRd
+.sem_scope_probe_mask <- function(area, subarea) {
+
+  subarea <- if (is.null(subarea) || !nzchar(as.character(subarea))) "WHOLE" else
+    as.character(subarea)
+  area_subarea <- core_name_cleaning(paste0(as.character(area), "_", subarea))
+
+  probe_features <- anno_probe_features_get(area_subarea)
+  if (is.null(probe_features) || nrow(probe_features) == 0)
+    return(NULL)
+  if (!(area_subarea %in% colnames(probe_features)))
+    stop(".sem_scope_probe_mask(): anno_probe_features_get('", area_subarea,
+         "') returned no '", area_subarea, "' column.")
+
+  membership <- as.character(probe_features[[area_subarea]])
+  keep <- !is.na(membership) & nzchar(trimws(membership))
+  mask <- unique(probe_features[keep, c("CHR", "START", "END"), drop = FALSE])
+  if (nrow(mask) == 0)
+    return(NULL)
+
+  # The POSITION pivot stores CHR without the "chr" prefix and the coordinates
+  # as Int32 (anno_create_position_pivots / io_stream_merge_bed); the manifest
+  # may carry either form.
+  mask$CHR   <- as.character(mask$CHR)
+  mask$START <- as.integer(mask$START)
+  mask$END   <- as.integer(mask$END)
+  mask <- mask[!is.na(mask$START) & !is.na(mask$END), , drop = FALSE]
+
+  polars::as_polars_df(mask)$lazy()$with_columns(
+    polars::pl$col("CHR")$cast(polars::pl$String)$str$replace("^(?i)chr", ""),
+    polars::pl$col("START")$cast(polars::pl$Int32),
+    polars::pl$col("END")$cast(polars::pl$Int32)
+  )
+}
+
+#' Burden per marker for one scope
 #'
 #' Moved here from sem_study_summary_total() (AI-223): the columns it used to
 #' append to the sample sheet were aggregated over the `POSITION` keys, i.e.
-#' they were already the `SAMPLE` scope of this artefact.
+#' they were already the `SAMPLE` scope of this artefact. AI-223 slice 2a adds
+#' the region scopes, computed from the same POSITION pivots restricted to the
+#' scope's probe mask.
 #'
+#' @param area,subarea `NULL` for the whole sample (scope `SAMPLE`), otherwise
+#'   the registered pair that defines the region scope.
 #' @keywords internal
 #' @noRd
-.sem_sample_burden_get <- function() {
+.sem_sample_burden_get <- function(area = NULL, subarea = NULL) {
 
   ssEnv <- core_get_session_info()
   keys <- ssEnv$keys_areas_subareas_markers_figures
   keys <- subset(keys, keys$AREA == "POSITION")
-  if (nrow(keys) == 0)
+  if (nrow(keys) == 0) {
+    # Every burden, whatever its scope, is aggregated from the POSITION pivots.
+    # A `subareas` argument that excludes WHOLE drops them (util_keys_create),
+    # and the sibling would come out empty without saying why.
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " No POSITION key in this run: no burden can be aggregated. ",
+              "Include \"WHOLE\" in `subareas` if you restricted it.")
     return(NULL)
+  }
+
+  scope <- io_scope_name(area = area, subarea = subarea)
+  mask  <- if (identical(scope, "SAMPLE")) NULL else .sem_scope_probe_mask(area, subarea)
+  if (!identical(scope, "SAMPLE") && is.null(mask)) {
+    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
+              " Scope ", scope, " selects no position; its burden columns are ",
+              "not written.")
+    return(NULL)
+  }
 
   result <- NULL
   for (k in seq_len(nrow(keys))) {
@@ -103,6 +238,15 @@ sem_sample_stats_build <- function() {
     if (is.null(pivot))
       next
 
+    if (!is.null(mask)) {
+      pivot <- pivot$with_columns(
+        polars::pl$col("CHR")$cast(polars::pl$String)$str$replace("^(?i)chr", ""),
+        polars::pl$col("START")$cast(polars::pl$Int32),
+        polars::pl$col("END")$cast(polars::pl$Int32)
+      )
+      pivot <- pivot$join(mask, on = c("CHR", "START", "END"), how = "semi")
+    }
+
     pivot <- pivot$drop(c("CHR", "START", "END"))
     # The operator is intrinsic to the marker: counts are summed, continuous
     # deviations averaged. DISCRETE is the flag that already encodes it
@@ -111,7 +255,7 @@ sem_sample_stats_build <- function() {
     pivot <- pivot$with_columns(polars::pl$col("*"))
 
     pivot <- as.data.frame(t(as.data.frame(pivot$collect())))
-    colname <- io_burden_colname("SAMPLE", marker, figure)
+    colname <- io_burden_colname(scope, marker, figure)
     colnames(pivot) <- colname
     pivot$Sample_ID <- rownames(pivot)
 

--- a/R/sem_semseeker.R
+++ b/R/sem_semseeker.R
@@ -46,6 +46,14 @@
 #'   positions that must be present in the reference annotation: the coverage
 #'   charts are written on every run, and the run stops below this threshold
 #'   (AI-074). Lower it explicitly for deliberate cross-technology runs.
+#'   \code{sample_stats_scopes} (default \code{"SAMPLE"}) selects the scopes of
+#'   the per-sample statistics sibling \code{SAMPLE_STATS_RESULT.csv}:
+#'   \code{"SAMPLE"} is the whole sample (always produced), and any registered
+#'   \code{AREA_SUBAREA} pair adds the burden restricted to that region class,
+#'   e.g. \code{sample_stats_scopes = c("SAMPLE", "GENE_TSS1500")} produces
+#'   \code{GENE_TSS1500_<MARKER>_<FIGURE>}. Each position is counted once, even
+#'   when it is annotated to several genes. Consume them at \code{depth = 1}
+#'   with \code{association_analysis(inference_details$scopes)}.
 #'
 #' @return Invisibly \code{NULL}; writes output files to \code{result_folder}.
 #'

--- a/man/association_analysis.Rd
+++ b/man/association_analysis.Rd
@@ -33,6 +33,14 @@ Required columns:
   \item{depth_analysis}{Integer depth: \code{1} = sample level,
     \code{2} = type level (gene, DMR, CpG island),
     \code{3} = genomic area (TSS1550, WHOLE, TSS200, …).}
+  \item{scopes}{Optional, depth=1 only. Which scopes of
+    \code{SAMPLE_STATS_RESULT.csv} to test, several separated by
+    \code{"+"} (default \code{"SAMPLE"}). A region scope such as
+    \code{"GENE_TSS1500"} tests the burden restricted to that region
+    class, still one value per sample: the result rows carry
+    \code{DEPTH = 1} with \code{AREA = "GENE_TSS1500"}. The scope must
+    have been produced by
+    \code{semseeker(sample_stats_scopes = ...)}, otherwise the run stops.}
 }}
 
 \item{result_folder}{character. Path to the SEMseeker result folder.}

--- a/man/semseeker.Rd
+++ b/man/semseeker.Rd
@@ -44,7 +44,19 @@ and \code{core_init_env()} (e.g. \code{parallel_strategy}, \code{alpha},
 \code{LESIONS_BP}, \code{marker}, \code{areas}). \code{LESIONS_BP}
 (default 2000) is the maximum bp distance between two probes for them to
 be in the same LESIONS enrichment window — replaces the legacy
-\code{sliding_window_size} probe-count parameter (removed in AI-092).}
+\code{sliding_window_size} probe-count parameter (removed in AI-092).
+\code{coverage_minimum} (default 80) is the minimum percentage of input
+positions that must be present in the reference annotation: the coverage
+charts are written on every run, and the run stops below this threshold
+(AI-074). Lower it explicitly for deliberate cross-technology runs.
+\code{sample_stats_scopes} (default \code{"SAMPLE"}) selects the scopes of
+the per-sample statistics sibling \code{SAMPLE_STATS_RESULT.csv}:
+\code{"SAMPLE"} is the whole sample (always produced), and any registered
+\code{AREA_SUBAREA} pair adds the burden restricted to that region class,
+e.g. \code{sample_stats_scopes = c("SAMPLE", "GENE_TSS1500")} produces
+\code{GENE_TSS1500_<MARKER>_<FIGURE>}. Each position is counted once, even
+when it is annotated to several genes. Consume them at \code{depth = 1}
+with \code{association_analysis(inference_details$scopes)}.}
 }
 \value{
 Invisibly \code{NULL}; writes output files to \code{result_folder}.

--- a/tests/testthat/test-0-sample-stats-sibling.R
+++ b/tests/testthat/test-0-sample-stats-sibling.R
@@ -25,6 +25,16 @@ test_that("io_scope_name encodes depth as scope", {
   expect_equal(SEMseeker:::io_scope_name(3L, "", ""), "SAMPLE")
 })
 
+test_that("io_scope_name derives the scope from (area, subarea) with no depth", {
+  # AI-223 slice 2a: the producer is depth-agnostic — it writes every scope
+  # once, so it names them from the pair alone.
+  expect_equal(SEMseeker:::io_scope_name(area = "GENE", subarea = "TSS1500"),
+               "GENE_TSS1500")
+  expect_equal(SEMseeker:::io_scope_name(area = "GENE"), "GENE")
+  expect_equal(SEMseeker:::io_scope_name(), "SAMPLE")
+  expect_equal(SEMseeker:::io_scope_name(area = "", subarea = "TSS1500"), "SAMPLE")
+})
+
 test_that("io_stat_colname and io_burden_colname compose the documented names", {
   expect_equal(SEMseeker:::io_stat_colname("SAMPLE", "MEDIAN"), "SAMPLE_MEDIAN")
   expect_equal(SEMseeker:::io_stat_colname("GENE_BODY", "IQR"), "GENE_BODY_IQR")
@@ -165,4 +175,199 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
   joined <- SEMseeker:::sem_study_summary_get()
   expect_true(all(burden_cols %in% colnames(joined)))
   expect_true("SAMPLE_MEDIAN" %in% colnames(joined))
+})
+
+# ---------------------------------------------------------------------------
+# AI-223 slice 2a — region scope, produced and consumed at depth = 1
+# ---------------------------------------------------------------------------
+
+test_that("a region scope reaches the sibling and the depth=1 inference", {
+  tempFolder <- tempFolders[14]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE)
+            unlink(tempFolder, recursive = TRUE) }, add = TRUE)
+
+  syn <- .burden_setup_signal_with_outliers()
+  scope <- SEMseeker:::io_scope_name(area = "GENE", subarea = "TSS1500")
+
+  SEMseeker::semseeker(
+    input               = syn$signal,
+    sample_sheet        = syn$samples,
+    result_folder       = tempFolder,
+    parallel_strategy   = "sequential",
+    # "WHOLE" must stay in `subareas`: it is what keeps POSITION_WHOLE in the
+    # keys, and every burden — whatever its scope — is aggregated from the
+    # POSITION pivots.
+    areas               = c("POSITION", "GENE"),
+    subareas            = c("WHOLE", "TSS1500"),
+    markers             = c("MUTATIONS"),
+    sample_stats_scopes = c("SAMPLE", scope),
+    start_fresh         = TRUE,
+    inpute              = "median",
+    showprogress        = showprogress,
+    verbosity           = verbosity
+  )
+
+  stats_csv <- file.path(tempFolder, "Data", "SAMPLE_STATS_RESULT.csv")
+  expect_true(file.exists(stats_csv))
+  skip_if_not(file.exists(stats_csv), "downstream assertions need the sibling")
+  stats <- utils::read.csv2(stats_csv, stringsAsFactors = FALSE)
+
+  scope_cols <- SEMseeker:::io_burden_colname(scope, "MUTATIONS", c("HYPER", "HYPO"))
+  whole_cols <- SEMseeker:::io_burden_colname("SAMPLE", "MUTATIONS", c("HYPER", "HYPO"))
+  expect_true(all(scope_cols %in% colnames(stats)),
+              info = paste("missing:",
+                           paste(setdiff(scope_cols, colnames(stats)), collapse = ", ")))
+  expect_true(all(whole_cols %in% colnames(stats)))
+
+  # a subset of the probes can only carry a subset of the burden
+  for (i in seq_along(scope_cols))
+    expect_true(all(stats[[scope_cols[i]]] <= stats[[whole_cols[i]]]))
+
+  # ── the mask counts every position once ──────────────────────────────────
+  SEMseeker:::core_init_env(result_folder = tempFolder, parallel_strategy = "sequential",
+                            areas = c("POSITION", "GENE"), subareas = c("WHOLE", "TSS1500"),
+                            markers = c("MUTATIONS"),
+                            start_fresh = FALSE, showprogress = FALSE, verbosity = 1)
+
+  mask <- SEMseeker:::.sem_scope_probe_mask("GENE", "TSS1500")
+  expect_false(is.null(mask))
+  skip_if(is.null(mask), "no probe of the fixture is annotated TSS1500")
+  mask_df <- as.data.frame(mask$collect())
+  expect_gt(nrow(mask_df), 0)
+
+  pivot <- SEMseeker:::io_read_pivot("MUTATIONS", "HYPER", "POSITION", "WHOLE")
+  pivot_df <- as.data.frame(pivot$collect())
+  pivot_df$CHR   <- sub("^(?i)chr", "", as.character(pivot_df$CHR), perl = TRUE)
+  pivot_df$START <- as.integer(pivot_df$START)
+  pivot_df$END   <- as.integer(pivot_df$END)
+  masked <- merge(pivot_df, mask_df, by = c("CHR", "START", "END"))
+  sample_columns <- setdiff(colnames(masked), c("CHR", "START", "END"))
+  expected <- colSums(masked[, sample_columns, drop = FALSE], na.rm = TRUE)
+
+  observed <- stats[[SEMseeker:::io_burden_colname(scope, "MUTATIONS", "HYPER")]]
+  names(observed) <- stats$Sample_ID
+  common <- intersect(names(expected), names(observed))
+  expect_gt(length(common), 0)
+  expect_equal(as.numeric(observed[common]), as.numeric(expected[common]))
+
+  # a probe annotated to several genes must not be counted twice: the mask has
+  # one row per position, whatever the annotation says
+  expect_equal(nrow(mask_df), nrow(unique(mask_df[, c("CHR", "START", "END")])))
+
+  # ── consumption at depth = 1 ─────────────────────────────────────────────
+  SEMseeker:::core_close_env()
+
+  inference_details <- data.frame(
+    independent_variable = "Phenotest",
+    family_test          = "spearman",
+    transformation_y     = "",
+    transformation_x     = "",
+    depth_analysis       = 1L,
+    scopes               = paste("SAMPLE", scope, sep = "+"),
+    filter_p_value       = FALSE,
+    stringsAsFactors     = FALSE
+  )
+
+  expect_no_error(
+    SEMseeker:::association_analysis(
+      inference_details = inference_details,
+      result_folder     = tempFolder,
+      parallel_strategy = "sequential",
+      markers           = c("MUTATIONS"),
+      # depth=1 reads the sibling, not the area pivots: no need to pay for the
+      # GENE keys here.
+      areas             = c("POSITION"),
+      multiple_test_adj = "BH",
+      showprogress      = showprogress,
+      verbosity         = verbosity
+    )
+  )
+
+  csv_files <- list.files(file.path(tempFolder, "Inference"), pattern = "\\.csv$",
+                          recursive = TRUE, full.names = TRUE)
+  csv_files <- csv_files[!grepl("(?i)assoc_covariates_model", csv_files)]
+  expect_gt(length(csv_files), 0)
+  skip_if(length(csv_files) == 0, "no inference CSV to inspect")
+
+  result_df <- do.call(plyr::rbind.fill,
+                       lapply(csv_files, function(f) utils::read.csv2(f, stringsAsFactors = FALSE)))
+  # the scope is one value per sample: still DEPTH 1, with the scope in AREA.
+  # which() and not a bare logical: the CSV carries rows with NA in AREA (the
+  # job-summary row), and `df[df$AREA == scope, ]` would materialise them as
+  # all-NA phantom rows.
+  scope_rows <- result_df[which(result_df$AREA == scope), , drop = FALSE]
+  expect_gt(nrow(scope_rows), 0)
+  expect_true(all(scope_rows$DEPTH == 1))
+  expect_true(all(scope_rows$SUBAREA == "SAMPLE"))
+  # which burden was tested stays in MARKER/FIGURE, as at every other depth;
+  # the scope is what AREA adds. (AREA_OF_TEST is "burden_values" on every
+  # depth=1 row, scoped or not: with a single tested column io_data_preparation
+  # loses the column name — pre-existing, see AI-247.)
+  expect_equal(sort(unique(scope_rows$MARKER)), "MUTATIONS")
+  expect_true(all(scope_rows$FIGURE %in% c("HYPER", "HYPO")))
+  expect_setequal(unique(scope_rows$FIGURE),
+                  unique(result_df[which(result_df$AREA == "SAMPLE_GROUP"), "FIGURE"]))
+  # and the whole-sample rows are still there, untouched
+  expect_gt(nrow(result_df[which(result_df$AREA == "SAMPLE_GROUP"), , drop = FALSE]), 0)
+})
+
+test_that("an unproduced scope stops the analysis instead of testing nothing", {
+  tempFolder <- tempFolders[15]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE)
+            unlink(tempFolder, recursive = TRUE) }, add = TRUE)
+
+  syn <- .burden_setup_signal_with_outliers()
+
+  SEMseeker::semseeker(
+    input             = syn$signal,
+    sample_sheet      = syn$samples,
+    result_folder     = tempFolder,
+    parallel_strategy = "sequential",
+    areas             = c("POSITION"),
+    markers           = c("MUTATIONS"),
+    start_fresh       = TRUE,
+    inpute            = "median",
+    showprogress      = showprogress,
+    verbosity         = verbosity
+  )
+
+  inference_details <- data.frame(
+    independent_variable = "Phenotest",
+    family_test          = "spearman",
+    transformation_y     = "",
+    transformation_x     = "",
+    depth_analysis       = 1L,
+    scopes               = "GENE_TSS1500",
+    filter_p_value       = FALSE,
+    stringsAsFactors     = FALSE
+  )
+
+  expect_error(
+    SEMseeker:::association_analysis(
+      inference_details = inference_details,
+      result_folder     = tempFolder,
+      parallel_strategy = "sequential",
+      markers           = c("MUTATIONS"),
+      areas             = c("POSITION"),
+      multiple_test_adj = "BH",
+      showprogress      = showprogress,
+      verbosity         = verbosity
+    ),
+    "GENE_TSS1500")
+})
+
+test_that("an unknown scope is refused by the producer, not silently ignored", {
+  tempFolder <- tempFolders[16]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE)
+            unlink(tempFolder, recursive = TRUE) }, add = TRUE)
+
+  SEMseeker:::core_init_env(result_folder = tempFolder, parallel_strategy = "sequential",
+                            areas = c("POSITION"), markers = c("MUTATIONS"),
+                            sample_stats_scopes = c("SAMPLE", "GENE_NOWHERE"),
+                            start_fresh = TRUE, showprogress = FALSE, verbosity = 1)
+
+  expect_error(SEMseeker:::.sem_stats_scopes_get(), "GENE_NOWHERE")
 })


### PR DESCRIPTION
Aggregates defined by a scope, computed and consumed at depth 1 (AI-223 slice 2a).

**Production.** `semseeker(sample_stats_scopes = c("SAMPLE","GENE_TSS1500"))`
adds `<SCOPE>_<MARKER>_<FIGURE>` to `SAMPLE_STATS_RESULT.csv`. A scope is an
already registered `(AREA, SUBAREA)` pair of the run; `SAMPLE` is always
produced; an unresolvable scope stops the run instead of being ignored.

**Consumption.** `inference_details$scopes` (e.g. `"SAMPLE+GENE_TSS1500"`)
selects which scopes `association_analysis()` tests at depth 1. Rows keep
`DEPTH = 1` and `SUBAREA = SAMPLE`, with the scope in `AREA`. Column names are
composed by the shared helper on both sides, never hard-coded.

**Each position counts once.** The scope burden comes from the POSITION pivot
restricted to the probe mask of the region, not from summing the annotated
per-area pivot: annotation explodes multi-gene probes, so that sum would count
a probe once per gene. As a consequence the producer does not need to move
after the annotation step, and the pipeline order is unchanged.

**Deliberately out of scope**: coordinate-resolved promoters, gene-model
pinning, backend unification, and region-scoped signal descriptors. The last
one depends on the aggregation taxonomy work order.

**Local tests (macOS)**: `test-0-sample-stats-sibling` 70/70,
`test-8-burden-integration` 56/56, `test-7-association_analysis` 38/38.
