### PR TITLE
ci: install limma before the Illumina annotation packages

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -150,12 +150,21 @@ jobs:
           #                                  test-5-annotation-concordance.R,
           #                                  test-5-area-granges-build.R (genomic
           #                                  feature joins)
+          # limma FIRST, and on its own. The three Illumina annotation packages
+          # load minfi while they install, minfi needs limma, and asking for all
+          # of them in one call does not guarantee limma is built before them:
+          # when limma came later in the same vector the annotation packages
+          # failed with "there is no package called 'limma'", left the runner
+          # with no annotation at all, and the suite fell back to the row-count
+          # technology heuristic and broke. A warm dependency cache hid this for
+          # months; moving the repository to an organisation reset the cache and
+          # exposed it.
+          BiocManager::install("limma", ask = FALSE, update = FALSE)
           BiocManager::install(
             c(
               "IlluminaHumanMethylationEPICanno.ilm10b4.hg19",
               "IlluminaHumanMethylation450kanno.ilmn12.hg19",
               "IlluminaHumanMethylation27kanno.ilmn12.hg19",
-              "limma",
               "AnnotationHub",
               "TxDb.Hsapiens.UCSC.hg19.knownGene"
             ),

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -61,12 +61,21 @@ jobs:
           # mirrors R-CMD-check.yml and is kept in sync by the
           # `test-0-suggests-installed.R` meta-test which fails CI if any
           # named pkg is missing.
+          # limma FIRST, and on its own. The three Illumina annotation packages
+          # load minfi while they install, minfi needs limma, and asking for all
+          # of them in one call does not guarantee limma is built before them:
+          # when limma came later in the same vector the annotation packages
+          # failed with "there is no package called 'limma'", left the runner
+          # with no annotation at all, and the suite fell back to the row-count
+          # technology heuristic and broke. A warm dependency cache hid this for
+          # months; moving the repository to an organisation reset the cache and
+          # exposed it.
+          BiocManager::install("limma", ask = FALSE, update = FALSE)
           BiocManager::install(
             c(
               "IlluminaHumanMethylationEPICanno.ilm10b4.hg19",
               "IlluminaHumanMethylation450kanno.ilmn12.hg19",
               "IlluminaHumanMethylation27kanno.ilmn12.hg19",
-              "limma",
               "AnnotationHub",
               "TxDb.Hsapiens.UCSC.hg19.knownGene"
             ),


### PR DESCRIPTION
The three annotation packages load minfi while they install, and minfi needs
limma. Asking for all of them in one BiocManager::install() call does not
guarantee limma is built first: with limma later in the same vector, the
annotation packages failed with

    there is no package called 'limma'
    Error : package 'minfi' could not be loaded
    installation of package 'IlluminaHumanMethylation450kanno...' had non-zero exit status

leaving the runner with no annotation at all. The suite then fell back to the
row-count technology heuristic — the 200-probe fixture resolves to K27 — and
asked for an annotation package that had just failed to install, producing 26
failures across the coverage gate and the sibling suites, none of them related
to the code under test.

A warm dependency cache had hidden this for months. Moving the repository to an
organisation reset the Actions caches, limma had to be built from scratch, and
the ordering defect surfaced. Both workflows carried it.
