### PR TITLE
feat!: name every computed quantity by scope, marker, figure and aggregation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,68 @@
 
 ## semseeker 0.99.5 (development)
 
+### Breaking changes
+
+- **Every computed quantity is now named by four coordinates (AI-248).** A
+  number produced by SEMseeker is the reduction of a set of genomic positions,
+  and until now the operator that reduced them was implicit — one per marker, so
+  the marker and its direction identified the value. A scope can carry several
+  reductions, so the operator became an axis of its own and the names changed
+  accordingly:
+
+  ```
+  <SCOPE>_<MARKER>_<FIGURE>_<AGGREGATION>
+  ```
+
+  | before | after |
+  |---|---|
+  | `SAMPLE_MUTATIONS_HYPER` | `SAMPLE_MUTATIONS_HYPER_SUM` |
+  | `SAMPLE_DELTAS_HYPO` | `SAMPLE_DELTAS_HYPO_MEAN` |
+  | `SAMPLE_MEDIAN` | `SAMPLE_SIGNAL_BETA_MEDIAN` |
+  | `SAMPLE_MODE_LOW` | `SAMPLE_SIGNAL_BETA_MODE_LOW` |
+  | `SAMPLE_N_PROBES` | unchanged — it is a property of the scope, not of a marker |
+
+- **The figure of `SIGNAL` is the scale of the values, `BETA` or `MVALUE`.** It
+  used to be `MEAN`, a placeholder that made the key unique while describing a
+  way of aggregating — which now has an axis of its own. Pivot files carry it,
+  so a beta run and an M-value run no longer write the same file name and
+  overwrite each other in one folder. WGBS, ONT and PacBio stay `BETA`: a
+  methylation fraction from reads is the same bounded scale as an array beta
+  value, and the package compares the two on purpose.
+
+- **Pivot file names carry the aggregation**, e.g.
+  `MUTATIONS_HYPER_CHR_CYTOBAND_SUM_hg19.parquet`. Result folders produced by
+  earlier versions do not match the new names and recompute once. This buys a
+  guarantee that did not exist: the name used to say nothing about which
+  operator had produced the file, so an existing pivot was reused on trust.
+
+- **`inference_details$aggregation` is required.** A request that does not name
+  the reduction does not identify what it wants tested. A malformed request (no
+  aggregation, or a name outside the taxonomy) stops the run; a request that no
+  marker of the run admits — the median of a 0/1 marker, say — drops that row
+  with a warning naming it and lets the other rows proceed.
+
+- **Results carry an `AGGREGATION` column**, part of the row identity along with
+  marker, figure, area and subarea, in the deduplication, in the resume match
+  and in the cross-study overlaps.
+
 ### New features
+
+- **Descriptors on any scope.** The signal descriptors are no longer a separate
+  path: `SIGNAL` is a marker like the others, so `sample_stats_scopes` now
+  produces its median, mean, variance, IQR and — on the beta scale — its two
+  modes restricted to a region class, e.g. `GENE_TSS1500_SIGNAL_BETA_MEDIAN`.
+
+- **Density.** The mean of a binary marker over a scope is the fraction of its
+  positions classified as epimutations. Unlike the raw burden it is comparable
+  between region classes of different size, which the burden is not.
+
+- Which reductions a marker admits is declared in one place. Continuous markers
+  (`SIGNAL`, `DELTAS`, `DELTAR`) take the full descriptor set; counts take the
+  sum and the mean, because their median and IQR are degenerate on a vector of
+  zeros and ones. The two modes assume a bounded bimodal scale and are therefore
+  restricted to the signal on the beta scale.
+
 
 - **Per-sample burden restricted to a region class (AI-223 slice 2a).** The
   statistics sibling can now carry a scope other than the whole sample:

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
   value, and the package compares the two on purpose.
 
 - **Pivot file names carry the aggregation**, e.g.
-  `MUTATIONS_HYPER_CHR_CYTOBAND_SUM_hg19.parquet`. Result folders produced by
+  `MUTATIONS_HYPER_CHR_CYTOBAND_SUM_HG19.parquet`. Result folders produced by
   earlier versions do not match the new names and recompute once. This buys a
   guarantee that did not exist: the name used to say nothing about which
   operator had produced the file, so an existing pivot was reused on trust.
@@ -85,6 +85,14 @@
   and `SUBAREA = "SAMPLE"`, with the scope in `AREA` (e.g. `GENE_TSS1500`) and
   `AREA_OF_TEST` unchanged. Requesting a scope that was never produced is an
   error naming the scope, not a silently empty result.
+
+### Documentation
+
+- The vignettes now show the names this version writes: `SIGNAL` pivots carry
+  the scale of the run (`SIGNAL_BETA_*`, or `SIGNAL_MVALUE_*`), file names are
+  uppercase, and the optional `AGGREGATION` segment is part of the documented
+  pattern. `sem_coverage_analysis_report()` describes its `signal_data` path
+  the same way.
 
 ## semseeker 0.99.4
 

--- a/R/anno_manhattan_plot_marker_per_probe.R
+++ b/R/anno_manhattan_plot_marker_per_probe.R
@@ -154,8 +154,8 @@ anno_manhattan_plot_marker_per_probe <- function(probe_name_max = "cg11680158", 
   tempKeys <- tempKeys[!grepl("SIGNAL", tempKeys)]
   # AI-027: read via unified dispatcher; cached parquet is the normal
   # path (CASE 1). The fname variable is kept for the error message below.
-  fname <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE","WHOLE")
-  signal_pivot_lazy <- io_read_pivot("SIGNAL", "MEAN", "PROBE", "WHOLE")
+  fname <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "PROBE","WHOLE")
+  signal_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
   if (is.null(signal_pivot_lazy))
     stop("SIGNAL_MEAN PROBE pivot not found at ", fname,
          " — manhattan plot requires the SEM signal pivot.")

--- a/R/anno_manhattan_plot_marker_per_probe.R
+++ b/R/anno_manhattan_plot_marker_per_probe.R
@@ -157,7 +157,7 @@ anno_manhattan_plot_marker_per_probe <- function(probe_name_max = "cg11680158", 
   fname <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "PROBE","WHOLE")
   signal_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
   if (is.null(signal_pivot_lazy))
-    stop("SIGNAL_MEAN PROBE pivot not found at ", fname,
+    stop("SIGNAL PROBE pivot not found at ", fname,
          " — manhattan plot requires the SEM signal pivot.")
   signal_data <- as.data.frame(signal_pivot_lazy$collect())
 

--- a/R/anno_probe_features_get.R
+++ b/R/anno_probe_features_get.R
@@ -57,7 +57,7 @@ anno_probe_features_get <- function(area_subarea) {
               "sem_prepare_batch_signal() should run first in the normal pipeline.")
     signal_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
     if (is.null(signal_pivot_lazy))
-      stop("SIGNAL_MEAN PROBE pivot not available — cannot detect technology.")
+      stop("SIGNAL PROBE pivot not available — cannot detect technology.")
     signal_data_r <- as.data.frame(signal_pivot_lazy$collect())
     if ("AREA" %in% colnames(signal_data_r)) {
       rownames(signal_data_r) <- signal_data_r$AREA
@@ -80,7 +80,7 @@ anno_probe_features_get <- function(area_subarea) {
   if (ssEnv$tech %in% c("WGBS", "LONGREAD")) {
 
     # AI-027: read via unified dispatcher. NULL means neither cached
-    # nor per-sample bed files exist for SIGNAL_MEAN — same failure
+    # nor per-sample bed files exist for SIGNAL — same failure
     # mode as the previous file.exists() check.
     sig_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
     if (is.null(sig_pivot_lazy))

--- a/R/anno_probe_features_get.R
+++ b/R/anno_probe_features_get.R
@@ -55,7 +55,7 @@ anno_probe_features_get <- function(area_subarea) {
     core_log_event("WARNING: anno_probe_features_get() called before ssEnv$tech is set. ",
               "Falling back to lazy detection from SIGNAL PROBE pivot. ",
               "sem_prepare_batch_signal() should run first in the normal pipeline.")
-    signal_pivot_lazy <- io_read_pivot("SIGNAL", "MEAN", "PROBE", "WHOLE")
+    signal_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
     if (is.null(signal_pivot_lazy))
       stop("SIGNAL_MEAN PROBE pivot not available — cannot detect technology.")
     signal_data_r <- as.data.frame(signal_pivot_lazy$collect())
@@ -82,7 +82,7 @@ anno_probe_features_get <- function(area_subarea) {
     # AI-027: read via unified dispatcher. NULL means neither cached
     # nor per-sample bed files exist for SIGNAL_MEAN — same failure
     # mode as the previous file.exists() check.
-    sig_pivot_lazy <- io_read_pivot("SIGNAL", "MEAN", "POSITION", "WHOLE")
+    sig_pivot_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
     if (is.null(sig_pivot_lazy))
       stop("POSITION pivot not found. Ensure io_signal_save() completed before ",
            "calling anno_probe_features_get() for area '", area_subarea, "'.")

--- a/R/assoc_analysis.R
+++ b/R/assoc_analysis.R
@@ -25,6 +25,17 @@
 #'     \item{depth_analysis}{Integer depth: \code{1} = sample level,
 #'       \code{2} = type level (gene, DMR, CpG island),
 #'       \code{3} = genomic area (TSS1550, WHOLE, TSS200, …).}
+#'     \item{aggregation}{Required. How the positions are reduced to the one
+#'       number the model is fitted on: \code{"SUM"}, \code{"MEAN"},
+#'       \code{"MEDIAN"}, \code{"VARIANCE"}, \code{"IQR"}, \code{"MODE_LOW"} or
+#'       \code{"MODE_HIGH"}. While every marker admitted exactly one operator
+#'       this could stay implicit; a scope now carries several, so the request
+#'       has to name the one it wants. Which are admissible depends on the
+#'       marker: a count carries \code{SUM} (the burden) and \code{MEAN} (the
+#'       density, the form comparable across regions of different size), while
+#'       its median and IQR are degenerate; the two modes exist only for the
+#'       signal on the beta scale. A request no marker of the run admits is
+#'       dropped with a warning naming it, not answered with an empty result.}
 #'     \item{scopes}{Optional, depth=1 only. Which scopes of
 #'       \code{SAMPLE_STATS_RESULT.csv} to test, several separated by
 #'       \code{"+"} (default \code{"SAMPLE"}). A region scope such as

--- a/R/assoc_analysis.R
+++ b/R/assoc_analysis.R
@@ -90,6 +90,10 @@ association_analysis <- function(inference_details, result_folder, maxResources 
   anno_annotate_position_pivots()
 
   inference_details <- assoc_validate_inference_schema(unique(inference_details))
+  # AI-248: shape first, then meaning. Refuse an aggregation that no marker of
+  # this run admits before any result is written — checking it inside the
+  # per-marker loop would surface the mistake after part of the output exists.
+  inference_details <- assoc_validate_aggregation(inference_details)
 
   for (z in seq_len(nrow(inference_details))) {
     start_time <- Sys.time()

--- a/R/assoc_analysis_save_results.R
+++ b/R/assoc_analysis_save_results.R
@@ -85,7 +85,9 @@ assoc_analysis_save_results <- function(results=NULL,fileNameResults, family_tes
   # remove duplicates based on MARKER   FIGURE  AREA    SUBAREA AREA_OF_TEST    FAMILY_TEST TRANSFORMATION_Y    PVALUE  R_MODEL
   # calculating the max of all others columns
   # C-06: include provenance columns in the grouping key so summarise() preserves them
-  group_column <- c("MARKER", "FIGURE", "AREA", "SUBAREA", "AREA_OF_TEST", "FAMILY_TEST",
+  # AI-248: AGGREGATION is part of the identity. Without it the summarise(max)
+  # below would fuse the median and the mean of the same scope into one row.
+  group_column <- c("MARKER", "FIGURE", "AGGREGATION", "AREA", "SUBAREA", "AREA_OF_TEST", "FAMILY_TEST",
                     "TRANSFORMATION_Y", "R_MODEL", "TRANSFORMATION_X",
                     "INDEPENDENT_VARIABLE", "COVARIATES",
                     "GENOME_BUILD", "TECH")

--- a/R/assoc_apply_stat_model.R
+++ b/R/assoc_apply_stat_model.R
@@ -177,6 +177,12 @@ assoc_apply_stat_model <- function(tempDataFrame, g_start, family_test, covariat
       local_result$FIGURE <-  as.character(key$FIGURE)
       local_result$AREA <-  as.character(key$AREA)
       local_result$SUBAREA <-  as.character(key$SUBAREA)
+      # AI-248: which operator reduced the positions to this number. Absent for
+      # the depths that do not aggregate, present wherever the caller declared
+      # it — and part of the row identity, so two aggregations of the same
+      # scope never collapse into one.
+      if (!is.null(key$AGGREGATION))
+        local_result$AGGREGATION <- as.character(key$AGGREGATION)
       # AI-106 (2026-06-09): reverse-map back to the upstream raw name
       # (HLA-A, chr10:100028204-100028508, ...) so the CSV preserves it
       # for enrichment / resume match. Fallback to burdenValue itself if

--- a/R/assoc_inter_study_association_overlaps.R
+++ b/R/assoc_inter_study_association_overlaps.R
@@ -71,10 +71,10 @@ assoc_inter_study_association_overlaps <- function(inference_detail, studies,alp
 
       if(statistic_parameter!="")
       {
-        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH",statistic_parameter, pvalue_column)]
+        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AGGREGATION","AREA_OF_TEST","DEPTH",statistic_parameter, pvalue_column)]
         # get only "AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH" common to STUDY
         tt <- tt %>%
-          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AREA_OF_TEST, .data$DEPTH) %>%
+          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AGGREGATION, .data$AREA_OF_TEST, .data$DEPTH) %>%
           dplyr::summarise(
             alpha = max(get(pvalue_column), na.rm = TRUE),
             statistic_parameter = mean(get(statistic_parameter), na.rm = TRUE)
@@ -84,10 +84,10 @@ assoc_inter_study_association_overlaps <- function(inference_detail, studies,alp
       }
       else
       {
-        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH",pvalue_column)]
+        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AGGREGATION","AREA_OF_TEST","DEPTH",pvalue_column)]
         # summarise grouping by "AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST" and calculate the max of the pvalues
         tt <- tt %>%
-          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AREA_OF_TEST, .data$DEPTH) %>%
+          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AGGREGATION, .data$AREA_OF_TEST, .data$DEPTH) %>%
           dplyr::summarise(
             alpha = max(get(pvalue_column), na.rm = TRUE)
           ) %>%
@@ -104,7 +104,7 @@ assoc_inter_study_association_overlaps <- function(inference_detail, studies,alp
         # remove statistic_parameter column
         old_results <- old_results[,!colnames(old_results) %in% c(statistic_parameter)]
         if(!pvalue_column %in% colnames(old_results))
-          tt <- merge(old_results, tt, all = TRUE, by = c("AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH"))
+          tt <- merge(old_results, tt, all = TRUE, by = c("AREA","SUBAREA","MARKER","FIGURE","AGGREGATION","AREA_OF_TEST","DEPTH"))
         # remove KEY COLUMN
         tt$KEY <- NULL
       }

--- a/R/assoc_intra_study_association_subsamples_overlaps.R
+++ b/R/assoc_intra_study_association_subsamples_overlaps.R
@@ -74,10 +74,10 @@ assoc_intra_study_association_subsamples_overlaps <- function(inference_details,
 
       if(statistic_parameter!="")
       {
-        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH",statistic_parameter, pvalue_column)]
+        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AGGREGATION","AREA_OF_TEST","DEPTH",statistic_parameter, pvalue_column)]
         # get only "AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH" common to SAMPLES_SQL_CONDITION
         tt <- tt %>%
-          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AREA_OF_TEST, .data$DEPTH) %>%
+          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AGGREGATION, .data$AREA_OF_TEST, .data$DEPTH) %>%
           dplyr::summarise(
             alpha = max(get(pvalue_column), na.rm = TRUE),
             statistic_parameter = mean(get(statistic_parameter), na.rm = TRUE)
@@ -87,10 +87,10 @@ assoc_intra_study_association_subsamples_overlaps <- function(inference_details,
       }
       else
       {
-        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST","DEPTH",pvalue_column)]
+        tt <- tt[,c("AREA","SUBAREA","MARKER","FIGURE","AGGREGATION","AREA_OF_TEST","DEPTH",pvalue_column)]
         # summarise grouping by "AREA","SUBAREA","MARKER","FIGURE","AREA_OF_TEST" and calculate the max of the pvalues
         tt <- tt %>%
-          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AREA_OF_TEST, .data$DEPTH) %>%
+          dplyr::group_by(.data$AREA, .data$SUBAREA, .data$MARKER, .data$FIGURE, .data$AGGREGATION, .data$AREA_OF_TEST, .data$DEPTH) %>%
           dplyr::summarise(
             alpha = max(get(pvalue_column), na.rm = TRUE)
           ) %>%

--- a/R/assoc_validate_aggregation.R
+++ b/R/assoc_validate_aggregation.R
@@ -52,8 +52,8 @@ assoc_validate_aggregation <- function(inference_details, keys = NULL) {
 
   impossible <- logical(nrow(inference_details))
 
-  legal <- unique(unlist(lapply(c(TRUE, FALSE), function(discrete)
-    util_aggregations_allowed("SIGNAL", "BETA", discrete = discrete, default = FALSE))))
+  # Spell-check only: the semantic check against the keys of the run is below.
+  legal <- util_aggregation_vocabulary()
 
   for (z in seq_len(nrow(inference_details))) {
     detail <- inference_details[z, ]

--- a/R/assoc_validate_aggregation.R
+++ b/R/assoc_validate_aggregation.R
@@ -1,0 +1,128 @@
+#' Validate the requested aggregations against the markers of the run
+#'
+#' AI-248. Semantic validation of `inference_details$aggregation`, run **at the
+#' door** of `association_analysis()` — before the session does any work, before
+#' a single result row is written. Checking it deeper, inside the per-marker
+#' loop, would mean discovering the mistake after part of the output already
+#' exists.
+#'
+#' It is the counterpart of `assoc_validate_inference_schema()`, which checks
+#' the *shape* of the request (which columns are legal). This one checks the
+#' *meaning*: that the aggregation exists in the taxonomy, and that at least one
+#' marker of this run admits it. Asking for the median of a 0/1 marker is
+#' refused here rather than answered with an empty result.
+#'
+#' The check lives here and not inside [io_feature_colname()] on purpose: the
+#' registry ([util_aggregations_allowed()]) says what is legal, the compositor
+#' says how it is named. Making the compositor validate would couple naming to
+#' the domain vocabulary and would break the callers that legitimately compose
+#' hypothetical names — the scope probe does exactly that to find out which
+#' columns a sibling actually carries.
+#'
+#' Two failure modes, treated differently on purpose:
+#' \itemize{
+#'   \item a **malformed** request — no aggregation named, or a name that is not
+#'     in the taxonomy — stops the run. It is a mistake in how the request was
+#'     written, and no rewriting of it can be trusted to mean what the author
+#'     intended;
+#'   \item an **impossible** request — a legal aggregation that none of this
+#'     run's markers admits, e.g. the median of a 0/1 marker — does not stop
+#'     anything: the row is dropped with a loud warning and the remaining rows
+#'     run. Losing one row of a batch is better than losing the batch, as long
+#'     as the loss is said out loud.
+#' }
+#' A request that is admissible for *some* markers keeps all its rows; the
+#' combinations that cannot be computed are named in a warning and skipped
+#' downstream.
+#'
+#' @param inference_details validated data.frame of requests.
+#' @param keys marker/figure keys of the run, defaults to the session's.
+#' @return `inference_details`, possibly with impossible rows removed. Callers
+#'   must use the returned value.
+#' @keywords internal
+#' @noRd
+assoc_validate_aggregation <- function(inference_details, keys = NULL) {
+
+  if (is.null(keys)) {
+    ssEnv <- core_get_session_info()
+    keys  <- ssEnv$keys_markers_figures
+  }
+  if (is.null(keys) || nrow(keys) == 0)
+    return(inference_details)
+
+  impossible <- logical(nrow(inference_details))
+
+  legal <- unique(unlist(lapply(c(TRUE, FALSE), function(discrete)
+    util_aggregations_allowed("SIGNAL", "BETA", discrete = discrete, default = FALSE))))
+
+  for (z in seq_len(nrow(inference_details))) {
+    detail <- inference_details[z, ]
+
+    depth <- detail$depth_analysis
+    if (is.null(depth) || length(depth) == 0 || is.na(depth))
+      depth <- 1
+    # Every depth, not just the sample level: a per-area value is an aggregate
+    # of the positions of that area exactly as a per-sample value is an
+    # aggregate of the positions of the scope. If the request does not name the
+    # operator, at any depth, it does not identify what it is asking for.
+    requested <- detail$aggregation
+    if (is.null(requested) || length(requested) == 0 || all(is.na(requested)) ||
+        !any(nzchar(as.character(requested))))
+      stop("inference_details row ", z, ": 'aggregation' is required at depth ",
+           depth, ". Name which aggregation of the feature to test (",
+           paste(legal, collapse = ", "), "). It used to be implicit because ",
+           "every marker admitted exactly one; a scope now carries several.",
+           call. = FALSE)
+
+    requested <- core_name_cleaning(as.character(requested)[1])
+    if (!(requested %in% legal))
+      stop("inference_details row ", z, ": aggregation = '", requested,
+           "' is not an aggregation of the taxonomy. Legal names: ",
+           paste(legal, collapse = ", "), ".", call. = FALSE)
+
+    admitted <- vapply(seq_len(nrow(keys)), function(i)
+      requested %in% util_aggregations_allowed(keys$MARKER[i], keys$FIGURE[i],
+                                               discrete = isTRUE(keys$DISCRETE[i]),
+                                               default  = FALSE),
+      logical(1))
+    if (!any(admitted)) {
+      impossible[z] <- TRUE
+      message_text <- paste0(
+        "inference_details row ", z, ": aggregation '", requested,
+        "' is admissible for none of the markers of this run (",
+        paste(unique(keys$MARKER), collapse = ", "),
+        "), so the row is dropped. A count marker carries SUM and MEAN — its ",
+        "median, variance and IQR are degenerate on a vector of zeros and ",
+        "ones; the two modes exist only for SIGNAL on the BETA scale.")
+      core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"), " ",
+                     message_text)
+      warning(message_text, call. = FALSE)
+      next
+    }
+
+    # Some admit it, some do not: the run goes ahead on the combinations that
+    # are possible, and says out loud which ones it is leaving out. Silence here
+    # would look exactly like a run that tested everything.
+    if (!all(admitted)) {
+      excluded <- unique(paste(keys$MARKER[!admitted], keys$FIGURE[!admitted],
+                               sep = "/"))
+      message_text <- paste0(
+        "aggregation '", requested, "' is not admissible for ",
+        paste(excluded, collapse = ", "),
+        ": those combinations are skipped, the run continues on the others.")
+      core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"), " ",
+                     message_text)
+      warning(message_text, call. = FALSE)
+    }
+  }
+
+  if (any(impossible)) {
+    inference_details <- inference_details[!impossible, , drop = FALSE]
+    if (nrow(inference_details) == 0)
+      stop("every row of inference_details asks for an aggregation that no ",
+           "marker of this run admits: there is nothing left to analyse.",
+           call. = FALSE)
+  }
+
+  inference_details
+}

--- a/R/assoc_validate_inference_schema.R
+++ b/R/assoc_validate_inference_schema.R
@@ -40,6 +40,11 @@ assoc_validate_inference_schema <- function(inference_details, strict = TRUE) {
     # statistics sibling ("SAMPLE", "GENE_TSS1500", …). Several are given
     # separated by "+", like covariates. Default "SAMPLE".
     "scopes",
+    # AI-248: which aggregation of the feature is tested (SUM, MEAN, MEDIAN,
+    # VARIANCE, IQR, MODE_LOW, MODE_HIGH). Mandatory at depth 1: with several
+    # aggregations over the same scope, a request that does not name one does
+    # not identify what it wants tested.
+    "aggregation",
     "filter_p_value",
     "samples_sql_condition",
     "areas_sql_condition",

--- a/R/core_get_meth_tech.R
+++ b/R/core_get_meth_tech.R
@@ -125,6 +125,10 @@ core_get_meth_tech <- function(signal_data) {
   else
     paste("INFO:", format(Sys.time(), "%a %b %d %X %Y"), "values appear to be M-values."))
 
+  # AI-248: the figure of SIGNAL is the scale, and the scale is only knowable
+  # here — the keys were built before any data was read.
+  ssEnv <- util_keys_signal_figure_refresh(ssEnv)
+
   ssEnv$probes_count <- n_probes
   core_update_session_info(ssEnv)
   core_log_event("JOURNAL: array technology set to:", ssEnv$tech)

--- a/R/io_feature_colname.R
+++ b/R/io_feature_colname.R
@@ -1,0 +1,45 @@
+#' Compose the column name of a computed feature (internal)
+#'
+#' AI-248. **The** single compositor of column names for the per-sample
+#' statistics sibling, used by the producer that writes it and by the consumer
+#' that references it. If the two sides built the string independently the
+#' contract would break at the first divergence, so nothing else in the package
+#' is allowed to paste these names together.
+#'
+#' The taxonomy has four axes, and the name carries them in order:
+#'
+#' \preformatted{
+#' <SCOPE>_<MARKER>_<FIGURE>_<AGGREGATION>
+#'
+#' SCOPE        SAMPLE (whole sample) | <AREA> | <AREA>_<SUBAREA>
+#' MARKER       SIGNAL | MUTATIONS | LESIONS | DELTA*
+#' FIGURE       HYPER / HYPO for the instability markers,
+#'              BETA / MVALUE (the scale) for SIGNAL
+#' AGGREGATION  SUM | MEAN | MEDIAN | VARIANCE | IQR | MODE_LOW | MODE_HIGH
+#' }
+#'
+#' Until AI-248 the aggregation was implicit — one operator per marker, so
+#' `MARKER`/`FIGURE` identified the value. With several aggregations over the
+#' same scope it no longer does, hence the fourth axis.
+#'
+#' Axes left `NULL` are dropped, which is how scope-level properties are named:
+#' `io_feature_colname("SAMPLE", aggregation = "N_PROBES")` gives
+#' `SAMPLE_N_PROBES` — the number of positions is a property of the scope, not
+#' an aggregation of a marker.
+#'
+#' @param scope scope name, as returned by [io_scope_name()]. Required.
+#' @param marker,figure,aggregation the remaining axes; `NULL` to omit.
+#' @return the column name, uppercase via [core_name_cleaning()].
+#' @keywords internal
+#' @noRd
+io_feature_colname <- function(scope, marker = NULL, figure = NULL,
+                               aggregation = NULL) {
+  if (missing(scope) || is.null(scope) || !all(nzchar(scope)))
+    stop("io_feature_colname(): 'scope' is required (use io_scope_name()).")
+
+  parts <- list(scope, marker, figure, aggregation)
+  parts <- parts[!vapply(parts, is.null, logical(1))]
+  parts <- lapply(parts, as.character)
+
+  core_name_cleaning(do.call(paste, c(parts, list(sep = "_"))))
+}

--- a/R/io_pivot_file_name.R
+++ b/R/io_pivot_file_name.R
@@ -1,25 +1,69 @@
-io_pivot_file_name <- function(marker,figure,area,subarea,add_gz=TRUE)
+#' Compose the on-disk name of a pivot (internal)
+#'
+#' AI-248. **The** single compositor of pivot file names — the file-name twin of
+#' [io_feature_colname()], which composes column names. Everything that reads or
+#' writes a pivot goes through here, so a pivot's identity is its name.
+#'
+#' \preformatted{
+#' <MARKER>_<FIGURE>_<AREA>_<SUBAREA>[_<AGGREGATION>]_<build>.parquet
+#'
+#' MUTATIONS_HYPER_CHR_CYTOBAND_SUM_hg19.parquet
+#' SIGNAL_BETA_CHR_CYTOBAND_MEAN_hg19.parquet
+#' SIGNAL_MVALUE_CHR_CYTOBAND_MEAN_hg19.parquet
+#' }
+#'
+#' The aggregation belongs in the name because before AI-248 the name did **not**
+#' say which operator had produced the file: an existing pivot was reused on
+#' trust. With one operator per marker that trust was justified; with several it
+#' would be the worst kind of bug — silent, because the file is there and the run
+#' does not complain while a mean is consumed as if it were a sum. With the
+#' aggregation in the key, an existing `MEAN` pivot is a `MEAN` and need not be
+#' recomputed, and a missing `MEDIAN` is visible.
+#'
+#' The same reasoning applies to the `SIGNAL` figure carrying the scale: today a
+#' beta run and an M-value run write the very same file name and overwrite each
+#' other in the same folder.
+#'
+#' @param marker,figure,area,subarea the four keys of the pivot.
+#' @param aggregation the AGGREGATION axis; `NULL` omits it, which is how the
+#'   POSITION-level pivots (one row per position, nothing aggregated yet) are
+#'   named.
+#' @param add_gz passed through for the CSV flavour.
+#' @keywords internal
+#' @noRd
+io_pivot_file_name <- function(marker, figure, area, subarea, add_gz = TRUE,
+                               aggregation = NULL)
 {
-  ssEnv <- core_get_session_info()
-  reportFolder <- io_dir_check_and_create(ssEnv$result_folderData,"Pivots")
-  pivot_subfolder <- io_dir_check_and_create(reportFolder, marker)
-  # C-06: append genome_build suffix (e.g. "_hg19") for belt-and-suspenders provenance
-  genome_suffix <- if (!is.null(ssEnv$genome_build) && nzchar(ssEnv$genome_build))
-    ssEnv$genome_build else "hg19"
-  pivot_base <- paste0(marker,"_", figure,"_",area,"_",subarea,"_",genome_suffix, sep = "")
-  io_pivot_file_name <- io_file_path_build(baseFolder =  pivot_subfolder,detailsFilename =  pivot_base,extension =  ".csv" ,add_gz=add_gz)
-  return(io_pivot_file_name)
+  .io_pivot_path(marker, figure, area, subarea, aggregation, ".csv", add_gz)
 }
 
-io_pivot_file_name_parquet <- function(marker,figure,area,subarea)
+#' @rdname io_pivot_file_name
+#' @keywords internal
+#' @noRd
+io_pivot_file_name_parquet <- function(marker, figure, area, subarea,
+                                       aggregation = NULL)
+{
+  .io_pivot_path(marker, figure, area, subarea, aggregation, ".parquet", FALSE)
+}
+
+#' @keywords internal
+#' @noRd
+.io_pivot_path <- function(marker, figure, area, subarea, aggregation,
+                           extension, add_gz)
 {
   ssEnv <- core_get_session_info()
-  reportFolder <- io_dir_check_and_create(ssEnv$result_folderData,"Pivots")
+  reportFolder <- io_dir_check_and_create(ssEnv$result_folderData, "Pivots")
   pivot_subfolder <- io_dir_check_and_create(reportFolder, marker)
   # C-06: append genome_build suffix (e.g. "_hg19") for belt-and-suspenders provenance
   genome_suffix <- if (!is.null(ssEnv$genome_build) && nzchar(ssEnv$genome_build))
     ssEnv$genome_build else "hg19"
-  pivot_base <- paste0(marker,"_", figure,"_",area,"_",subarea,"_",genome_suffix, sep = "")
-  io_pivot_file_name <- io_file_path_build(baseFolder =  pivot_subfolder,detailsFilename =  pivot_base,extension =  ".parquet" ,add_gz=FALSE)
-  return(io_pivot_file_name)
+
+  parts <- c(marker, figure, area, subarea)
+  if (!is.null(aggregation) && nzchar(as.character(aggregation)))
+    parts <- c(parts, as.character(aggregation))
+  parts <- c(parts, genome_suffix)
+
+  pivot_base <- paste(parts, collapse = "_")
+  io_file_path_build(baseFolder = pivot_subfolder, detailsFilename = pivot_base,
+                     extension = extension, add_gz = add_gz)
 }

--- a/R/io_signal_figure.R
+++ b/R/io_signal_figure.R
@@ -1,0 +1,35 @@
+#' The FIGURE of the SIGNAL marker for this session (internal)
+#'
+#' AI-248. `SIGNAL` used to carry the figure `MEAN`, which was a **placeholder**
+#' that made the key unique — not a statement about the data. It described (badly)
+#' a way of aggregating the signal, and now that aggregation has an axis of its
+#' own the placeholder has to go.
+#'
+#' The figure of `SIGNAL` is the **scale** of the value: `BETA` for a bounded
+#' proportion in [0,1] — an array beta value, or a methylation fraction from
+#' reads, which is the same scale — and `MVALUE` for the logit-transformed one.
+#' The scale is already detected once per session by `core_get_meth_tech()`.
+#'
+#' The technology (`ssEnv$tech`) deliberately does **not** enter here: WGBS,
+#' ONT and PacBio produce fractions in [0,1] and are `BETA` like an array is.
+#' The package compares array and sequencing on purpose — see
+#' `test-cross-format-convergence.R` — and giving the same scale two different
+#' labels would misalign exactly those comparisons. Provenance is recorded
+#' elsewhere (`ssEnv$tech`, the `TECH` column stamped on results).
+#'
+#' @param beta logical, defaults to the scale of the current session.
+#' @return `"BETA"` or `"MVALUE"`.
+#' @keywords internal
+#' @noRd
+io_signal_figure <- function(beta = NULL) {
+  if (is.null(beta)) {
+    ssEnv <- core_get_session_info()
+    beta <- ssEnv$beta
+  }
+  # An unset scale means the session has not seen the data yet; the bounded
+  # scale is the package default (core_get_meth_tech sets it on first read).
+  if (is.null(beta) || length(beta) != 1L || is.na(beta))
+    beta <- TRUE
+
+  if (isTRUE(beta)) "BETA" else "MVALUE"
+}

--- a/R/io_signal_save.R
+++ b/R/io_signal_save.R
@@ -10,7 +10,7 @@ io_signal_save <- function(signal_data, sample_sheet, batch_id,
   if (is.null(probe_features))
     probe_features <- attr(signal_data, "probe_features")
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"), "Saving signal data.")
-  pivot_file_name_pos <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "POSITION", "WHOLE")
+  pivot_file_name_pos <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
   if (file.exists(pivot_file_name_pos)) {
     core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"), "Signal data already saved.")
     return()
@@ -40,7 +40,7 @@ io_signal_save <- function(signal_data, sample_sheet, batch_id,
     signal_probe$AREA      <- rownames(signal_data)
     signal_probe           <- signal_probe[, c(ncol(signal_probe),
                                                seq_len(ncol(signal_probe) - 1))]
-    pivot_file_name_probe  <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE", "WHOLE")
+    pivot_file_name_probe  <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
     polars::as_polars_df(signal_probe)$write_parquet(pivot_file_name_probe)
     rm(signal_probe)
 
@@ -74,7 +74,7 @@ io_signal_save <- function(signal_data, sample_sheet, batch_id,
   signal_data$AREA <- rownames(signal_data)
   signal_data      <- signal_data[, c(ncol(signal_data), seq_len(ncol(signal_data) - 1))]
 
-  pivot_file_name_probe <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE", "WHOLE")
+  pivot_file_name_probe <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")
   polars::as_polars_df(signal_data)$write_parquet(pivot_file_name_probe)
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"), "Signal data saved with probe.")
 
@@ -122,7 +122,7 @@ io_signal_save <- function(signal_data, sample_sheet, batch_id,
   # Scan parquet UNA SOLA VOLTA fuori dal loop: la lazy frame è immutabile,
   # ogni $filter/$join in iterazione produce una nuova lazy frame senza
   # ri-aprire il parquet. Riduce overhead per iter su big matrix.
-  sd_lazy <- io_read_pivot("SIGNAL", "MEAN", "PROBE", "WHOLE")$
+  sd_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "PROBE", "WHOLE")$
               with_columns(polars::pl$col("AREA")$alias("PROBE"))
 
   for (i in seq_along(chrs)) {

--- a/R/sem_analyze_batch.R
+++ b/R/sem_analyze_batch.R
@@ -35,7 +35,7 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
   sample_sheet <- core_normalize_sample_ids(sample_sheet)$sample_sheet
 
   # AI-027: read via unified dispatcher. CASE 2 (streaming merge) lets
-  # the SEM step pick up raw bed/bedgraph files when the SIGNAL_MEAN
+  # the SEM step pick up raw bed/bedgraph files when the SIGNAL
   # pivot has not been materialised yet.
   signal_pivot <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
   resume_mode  <- !is.null(signal_pivot)

--- a/R/sem_analyze_batch.R
+++ b/R/sem_analyze_batch.R
@@ -37,7 +37,7 @@ sem_analyze_batch <- function(signal_data, sample_sheet)
   # AI-027: read via unified dispatcher. CASE 2 (streaming merge) lets
   # the SEM step pick up raw bed/bedgraph files when the SIGNAL_MEAN
   # pivot has not been materialised yet.
-  signal_pivot <- io_read_pivot("SIGNAL", "MEAN", "POSITION", "WHOLE")
+  signal_pivot <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
   resume_mode  <- !is.null(signal_pivot)
 
   if (resume_mode) {

--- a/R/sem_analyze_population.R
+++ b/R/sem_analyze_population.R
@@ -72,7 +72,7 @@ sem_analyze_population <- function(signal_data, sample_sheet,signal_thresholds, 
     )
     candidates[grepl(paste0("/", pattern, "/"), candidates, fixed = TRUE)]
   }
-  existing_signal_mean <- .existing_bed_set("SIGNAL", "MEAN")
+  existing_signal_mean <- .existing_bed_set("SIGNAL", io_signal_figure())
   existing_mut_hyper   <- .existing_bed_set("MUTATIONS", "HYPER")
   existing_mut_hypo    <- .existing_bed_set("MUTATIONS", "HYPO")
   existing_deltas_hypo <- .existing_bed_set("DELTAS", "HYPO")
@@ -101,7 +101,7 @@ sem_analyze_population <- function(signal_data, sample_sheet,signal_thresholds, 
   # foreach::foreach(i =1:nrow(sample_sheet), .export = variables_to_export) %dorng% {
     local_sample_detail <- sample_sheet[i,]
     ssEnv <- core_get_session_info()
-    bed_filename <- io_bed_file_name(local_sample_detail$Sample_ID,local_sample_detail$Sample_Group, "SIGNAL","MEAN", skip_dir_create = dir_known_signal_mean)
+    bed_filename <- io_bed_file_name(local_sample_detail$Sample_ID,local_sample_detail$Sample_Group, "SIGNAL", io_signal_figure(), skip_dir_create = dir_known_signal_mean)
     if(!(bed_filename %in% existing_signal_mean)) {
       signal_values <- signal_data[,local_sample_detail$Sample_ID]
       sem_signal_single_sample( signal_values,local_sample_detail,probe_features)
@@ -121,7 +121,7 @@ sem_analyze_population <- function(signal_data, sample_sheet,signal_thresholds, 
     coverage_first_sample <- sample_sheet[1L, ]
     coverage_bed <- io_bed_file_name(coverage_first_sample$Sample_ID,
                                   coverage_first_sample$Sample_Group,
-                                  "SIGNAL", "MEAN")
+                                  "SIGNAL", io_signal_figure())
     if (file.exists(coverage_bed)) {
       coverage_sig <- utils::read.delim(coverage_bed, header = FALSE, sep = "\t")
       colnames(coverage_sig) <- c("CHR", "START", "END", "VALUE")
@@ -192,7 +192,7 @@ sem_analyze_population <- function(signal_data, sample_sheet,signal_thresholds, 
 
     # Only pay the read.delim cost when at least one figure needs computing.
     if (need_mut_hyper || need_mut_hypo || need_deltas_hypo || need_deltar_hypo) {
-      bed_filename <- SEMseeker:::io_bed_file_name(local_sample_detail$Sample_ID,local_sample_detail$Sample_Group, "SIGNAL","MEAN")
+      bed_filename <- SEMseeker:::io_bed_file_name(local_sample_detail$Sample_ID,local_sample_detail$Sample_Group, "SIGNAL", io_signal_figure())
       signal_values <- utils::read.delim(bed_filename, header = FALSE, sep = "\t")
       colnames(signal_values) <- c("CHR", "START", "END", "VALUE")
       signal_values$CHR <- SEMseeker:::anno_normalize_chr(signal_values$CHR, "internal")

--- a/R/sem_analyze_population_bulk.R
+++ b/R/sem_analyze_population_bulk.R
@@ -73,7 +73,7 @@ sem_analyze_population_bulk <- function(signal_data, sample_sheet,
     return(invisible(NULL))
   }
 
-  signal_pivot_path <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "POSITION", "WHOLE")
+  signal_pivot_path <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
   if (!file.exists(signal_pivot_path)) {
     stop("[sem_analyze_population_bulk] SIGNAL POSITION pivot mancante: ",
          signal_pivot_path,
@@ -126,14 +126,14 @@ sem_analyze_population_bulk <- function(signal_data, sample_sheet,
   # tocca le sample. Quindi possiamo derivarlo dal pivot raw senza pagare
   # quel picco.
   raw_signal_schema <- names(
-    io_read_pivot("SIGNAL", "MEAN", "POSITION", "WHOLE")$collect_schema()
+    io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")$collect_schema()
   )
   coord_cols  <- c("CHR", "START", "END", ".HIGH", ".LOW")
   sample_cols <- setdiff(raw_signal_schema, coord_cols)
 
   # Carica SIGNAL pivot lazy + cast CHR to String (io_signal_save lascia Categorical
   # mentre thr_lazy ha String -> mismatch nel join) + join thresholds
-  signal_lazy <- io_read_pivot("SIGNAL", "MEAN", "POSITION", "WHOLE")$
+  signal_lazy <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")$
     with_columns(polars::pl$col("CHR")$cast(polars::pl$String))$
     join(thr_lazy, on = c("CHR", "START", "END"), how = "inner")
 

--- a/R/sem_coverage_analysis_report.R
+++ b/R/sem_coverage_analysis_report.R
@@ -27,7 +27,7 @@ sem_coverage_analysis_report <- function (signal_data, result_folder, maxResourc
 {
 
   ssEnv <- core_init_env( result_folder =  result_folder, maxResources =  maxResources, ...)
-  # signal_data_path <- io_pivot_file_name_parquet("SIGNAL","MEAN","PROBE","WHOLE")
+  # signal_data_path <- io_pivot_file_name_parquet("SIGNAL", io_signal_figure(),"PROBE","WHOLE")
   # if (!file.exists(signal_data_path))
   # {
   #   core_log_event("ERROR:  ", format(Sys.time(), "%a %b %d %X %Y"), " Signal data is missing")

--- a/R/sem_coverage_analysis_report.R
+++ b/R/sem_coverage_analysis_report.R
@@ -3,9 +3,11 @@
 #'   array data, summarising probe representation across genomic regions.
 #'   WGBS data are not supported and will cause the function to stop with an
 #'   informative error.
-#' @param signal_data character. Path to the signal parquet file (e.g.
-#'   \code{Data/SIGNAL_MEAN_PROBE_WHOLE.parquet}) or a data.frame already
-#'   loaded into memory.
+#' @param signal_data character. Path to the signal parquet file under
+#'   \code{Data/Pivots/SIGNAL/}, or a data.frame already loaded into memory.
+#'   The file is named \code{SIGNAL_<FIGURE>_PROBE_WHOLE_<GENOME_BUILD>.parquet},
+#'   where \code{FIGURE} is the scale the run was written on — \code{BETA} for a
+#'   proportion bounded in [0,1], \code{MVALUE} for the logit-transformed one.
 #' @param result_folder character. Path to the SEMseeker result folder.
 #' @param maxResources numeric. Maximum percentage of CPU cores to use
 #'   (default 90).
@@ -17,8 +19,10 @@
 #' @examples
 #' result_dir <- tempdir()
 #' \dontrun{
+#' # BETA is the scale this particular run was written on; a run on the
+#' # logit scale produces SIGNAL_MVALUE_PROBE_WHOLE_HG19.parquet instead.
 #' sem_coverage_analysis_report(
-#'   signal_data   = "~/semseeker_results/Data/SIGNAL_MEAN_PROBE_WHOLE.parquet",
+#'   signal_data   = "~/semseeker_results/Data/Pivots/SIGNAL/SIGNAL_BETA_PROBE_WHOLE_HG19.parquet",
 #'   result_folder = "~/semseeker_results/"
 #' )
 #' }

--- a/R/sem_run_depth1_marker.R
+++ b/R/sem_run_depth1_marker.R
@@ -30,7 +30,8 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   # (e.g. GENE_TSS1500 = burden restricted to the probes of that region class).
   # It is still one value per sample, hence still DEPTH=1; the scope is what
   # the AREA column carries.
-  scopes <- .sem_depth1_scopes_get(prep, ssEnv)
+  scopes      <- .sem_depth1_scopes_get(prep, ssEnv)
+  aggregation <- .sem_depth1_aggregation_get(prep)
 
   # resume: drop keys already present in the CSV (DEPTH==1 only). Read once,
   # the scope is part of the identity through AREA.
@@ -40,7 +41,7 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   if (file_good) {
     old_results <- unique(utils::read.csv2(fileNameResults, header = TRUE))
     old_filtered <- old_results[old_results$DEPTH == 1, ]
-    done_ids <- unlist(apply(unique(old_filtered[, c("MARKER", "FIGURE", "AREA", "SUBAREA")]), 1,
+    done_ids <- unlist(apply(unique(old_filtered[, intersect(c("MARKER", "FIGURE", "AGGREGATION", "AREA", "SUBAREA"), colnames(old_filtered))]), 1,
       function(x) paste(x, collapse = "_", sep = "")))
   }
 
@@ -48,12 +49,16 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   for (scope in scopes) {
     scope_keys  <- keys
     cols        <- scope_keys$COMBINED
-    burden_cols <- io_burden_colname(scope, scope_keys$MARKER, scope_keys$FIGURE)
+    # AI-248: the four axes of the taxonomy, composed by the one compositor the
+    # producer also uses. The aggregation is the axis the request must name.
+    burden_cols <- io_feature_colname(scope, scope_keys$MARKER, scope_keys$FIGURE,
+                                      aggregation)
     present     <- burden_cols %in% colnames(prep$study_summary)
     if (sum(present) == 0) {
       if (!identical(scope, "SAMPLE"))
         core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
-          " Scope ", scope, " carries no burden column for this marker; skipped.")
+          " Scope ", scope, " carries no ", aggregation,
+          " column for this marker; skipped.")
       next
     }
 
@@ -66,8 +71,12 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
     study_summary_scope <- .sem_burden_cols_rename(prep$study_summary, burden_cols, cols)
     # SUBAREA == "SAMPLE" is what makes assoc_analysis_save_results() stamp
     # DEPTH = 1; AREA says which scope was aggregated.
-    scope_keys$AREA    <- if (identical(scope, "SAMPLE")) "SAMPLE_GROUP" else scope
-    scope_keys$SUBAREA <- "SAMPLE"
+    scope_keys$AREA        <- if (identical(scope, "SAMPLE")) "SAMPLE_GROUP" else scope
+    scope_keys$SUBAREA     <- "SAMPLE"
+    # AI-248: which operator produced the number travels with the row. Without
+    # it two aggregations of the same scope would be indistinguishable, and the
+    # dedup in assoc_analysis_save_results() would fuse them into one.
+    scope_keys$AGGREGATION <- aggregation
 
     has_covariates <- !is.null(prep$covariates) && length(prep$covariates) != 0
     if (has_covariates) {
@@ -78,7 +87,7 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
     }
 
     if (length(done_ids) > 0) {
-      todo_ids <- unlist(apply(scope_keys[, c("MARKER", "FIGURE", "AREA", "SUBAREA")], 1,
+      todo_ids <- unlist(apply(scope_keys[, c("MARKER", "FIGURE", "AGGREGATION", "AREA", "SUBAREA")], 1,
         function(x) paste(x, collapse = "_", sep = "")))
       scope_keys <- scope_keys[!(todo_ids %in% done_ids), ]
     }
@@ -146,6 +155,38 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   list(results = results, processed_items = processed_items)
 }
 
+#' The aggregation the request asks for (internal)
+#'
+#' AI-248. Mandatory at depth 1. While every marker admitted exactly one
+#' operator the axis could stay implicit; now that a scope carries several, a
+#' request that does not name one does not identify what it wants tested — and
+#' silently picking one for the researcher is how a median gets reported as a
+#' mean.
+#'
+#' @keywords internal
+#' @noRd
+.sem_depth1_aggregation_get <- function(prep) {
+
+  requested <- prep$inference_detail$aggregation
+  if (is.null(requested) || length(requested) == 0 || all(is.na(requested)) ||
+      !any(nzchar(as.character(requested))))
+    stop("inference_details$aggregation is required at depth 1: name which ",
+         "aggregation of the feature to test (SUM, MEAN, MEDIAN, VARIANCE, ",
+         "IQR, MODE_LOW, MODE_HIGH). It used to be implicit because every ",
+         "marker admitted exactly one; a scope now carries several.")
+
+  requested <- core_name_cleaning(as.character(requested)[1])
+  legal <- unique(unlist(lapply(c(TRUE, FALSE), function(discrete)
+    util_aggregations_allowed("SIGNAL", "BETA", discrete = discrete, default = FALSE))))
+  if (!(requested %in% legal))
+    stop("inference_details$aggregation = '", requested, "' is not an ",
+         "aggregation of the taxonomy. Legal names: ",
+         paste(legal, collapse = ", "), ".")
+
+  # The coherence check lives at the door, in assoc_validate_aggregation().
+  requested
+}
+
 #' Scopes to test at depth=1, validated against the statistics sibling
 #'
 #' AI-223 slice 2a. `inference_details$scopes` names them the way the sibling
@@ -174,7 +215,10 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
   all_keys <- ssEnv$keys_markers_figures
   known_cols <- colnames(prep$study_summary)
   for (scope in requested) {
-    candidates <- io_burden_colname(scope, all_keys$MARKER, all_keys$FIGURE)
+    # a scope is present if ANY of its columns is, whatever the aggregation
+    candidates <- unlist(lapply(c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR"),
+      function(aggregation)
+        io_feature_colname(scope, all_keys$MARKER, all_keys$FIGURE, aggregation)))
     if (!any(candidates %in% known_cols))
       stop("inference_details$scopes: scope '", scope, "' has no column in ",
            "SAMPLE_STATS_RESULT. Produce it with ",

--- a/R/sem_run_depth1_marker.R
+++ b/R/sem_run_depth1_marker.R
@@ -176,8 +176,9 @@ sem_run_depth1_marker <- function(prep, keys, family_test, fileNameResults,
          "marker admitted exactly one; a scope now carries several.")
 
   requested <- core_name_cleaning(as.character(requested)[1])
-  legal <- unique(unlist(lapply(c(TRUE, FALSE), function(discrete)
-    util_aggregations_allowed("SIGNAL", "BETA", discrete = discrete, default = FALSE))))
+  # Spell-check only: the coherence check lives at the door, in
+  # assoc_validate_aggregation().
+  legal <- util_aggregation_vocabulary()
   if (!(requested %in% legal))
     stop("inference_details$aggregation = '", requested, "' is not an ",
          "aggregation of the taxonomy. Legal names: ",

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -33,34 +33,28 @@ sem_sample_stats_build <- function() {
 
   ssEnv <- core_get_session_info()
 
-  burden <- NULL
+  stats  <- NULL
   scopes <- .sem_stats_scopes_get()
   core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
             " Per-sample statistics, scopes: ",
             paste(vapply(scopes, function(s) s$scope, character(1)), collapse = ", "), ".")
   for (scope in scopes) {
-    scope_burden <- .sem_sample_burden_get(scope$area, scope$subarea)
-    if (is.null(scope_burden))
+    # AI-248: one call covers every marker of the scope and, for each, every
+    # aggregation it carries — the signal descriptors included, since SIGNAL is
+    # a marker like the others and its figure is the scale of the values.
+    scope_stats <- .sem_sample_burden_get(scope$area, scope$subarea)
+    if (is.null(scope_stats))
       next
-    burden <- if (is.null(burden)) scope_burden else
-      merge(burden, scope_burden, by = "Sample_ID", all = TRUE)
+    stats <- if (is.null(stats)) scope_stats else
+      merge(stats, scope_stats, by = "Sample_ID", all = TRUE)
   }
 
-  # Signal descriptors stay at sample level: the region-scoped descriptors are
-  # a separate decision (they are not marker/figure pairs, so they do not
-  # travel through the keys machinery the way the burden does).
-  descriptors <- .sem_sample_descriptors_get()
-
-  if (is.null(burden) && is.null(descriptors)) {
+  if (is.null(stats)) {
     core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
               " No per-sample statistics could be computed; ",
               "SAMPLE_STATS_RESULT not written.")
     return(invisible(NULL))
   }
-
-  stats <- if (is.null(burden)) descriptors else
-           if (is.null(descriptors)) burden else
-           merge(descriptors, burden, by = "Sample_ID", all = TRUE)
 
   # Sample sheet identifiers are the reference: report what the pivots know
   # about samples the sheet does not mention, and vice versa (AI-083).
@@ -231,8 +225,8 @@ sem_sample_stats_build <- function() {
   result <- NULL
   for (k in seq_len(nrow(keys))) {
     key     <- keys[k, ]
-    marker  <- key$MARKER
-    figure  <- key$FIGURE
+    marker  <- as.character(key$MARKER)
+    figure  <- as.character(key$FIGURE)
 
     pivot <- io_read_pivot(marker, figure, key$AREA, key$SUBAREA)
     if (is.null(pivot))
@@ -246,105 +240,85 @@ sem_sample_stats_build <- function() {
       )
       pivot <- pivot$join(mask, on = c("CHR", "START", "END"), how = "semi")
     }
-
     pivot <- pivot$drop(c("CHR", "START", "END"))
-    # The operator is intrinsic to the marker: counts are summed, continuous
-    # deviations averaged. DISCRETE is the flag that already encodes it
-    # (util_keys_create.R).
-    pivot <- if (isTRUE(key$DISCRETE)) pivot$sum() else pivot$mean()
-    pivot <- pivot$with_columns(polars::pl$col("*"))
 
-    pivot <- as.data.frame(t(as.data.frame(pivot$collect())))
-    colname <- io_burden_colname(scope, marker, figure)
-    colnames(pivot) <- colname
-    pivot$Sample_ID <- rownames(pivot)
+    # AI-248: the operator is no longer a boolean intrinsic to the marker. The
+    # registry says which aggregations this pair carries; DISCRETE now only
+    # decides which one is produced without being asked.
+    aggregations <- util_aggregations_allowed(marker, figure,
+                                              discrete = isTRUE(key$DISCRETE),
+                                              default  = TRUE)
+    # The number of usable positions is a property of the SCOPE, not an
+    # aggregation of a marker, so it carries no marker/figure in its name. It is
+    # read off the signal, which is the only marker present at every position.
+    if (identical(marker, "SIGNAL"))
+      aggregations <- c(aggregations, "N_PROBES")
 
-    if (is.null(result)) {
-      result <- pivot
-    } else {
-      result <- result[, !(colnames(result) == colname), drop = FALSE]
-      result <- merge(result, pivot, by = "Sample_ID", all = TRUE)
+    for (aggregation in aggregations) {
+      values <- .sem_pivot_aggregate(pivot, aggregation)
+      if (is.null(values))
+        next
+      colname <- if (identical(aggregation, "N_PROBES"))
+        io_feature_colname(scope, aggregation = aggregation) else
+        io_feature_colname(scope, marker, figure, aggregation)
+      colnames(values) <- colname
+      values$Sample_ID <- rownames(values)
+      rownames(values) <- NULL
+
+      if (is.null(result)) {
+        result <- values
+      } else {
+        result <- result[, !(colnames(result) == colname), drop = FALSE]
+        result <- merge(result, values, by = "Sample_ID", all = TRUE)
+      }
     }
   }
 
   if (is.null(result))
     return(NULL)
 
-  result[is.na(result)] <- 0
   rownames(result) <- NULL
   result
 }
 
-#' Signal descriptors at sample level
+#' Reduce every sample column of a pivot with one aggregation (internal)
 #'
-#' One pass per sample over the SIGNAL pivot, parallelised with the same
-#' foreach/%dorng% idiom used elsewhere in the package. Each worker collects a
-#' single sample column (one column ~ n_probes doubles, so memory stays bounded
-#' by the number of workers, not by the size of the matrix) and reduces it to
-#' one row of statistics.
+#' AI-248. Two paths, and the difference is not cosmetic:
 #'
+#' \itemize{
+#'   \item `SUM` and `MEAN` are streaming reduces: polars computes them over the
+#'     whole frame without materialising a single column in R;
+#'   \item everything else needs the distribution — a median must sort, the two
+#'     modes must estimate a density — so each sample column is collected in
+#'     turn and reduced in R. One column at a time keeps memory bounded by the
+#'     number of workers, not by the size of the matrix, which is the same idiom
+#'     the rest of the package uses.
+#' }
+#'
+#' @param pivot lazy polars frame, sample columns only (keys already dropped).
+#' @param aggregation one name from [util_aggregations_allowed()].
+#' @return a one-column data.frame, rows named by sample, or `NULL`.
 #' @keywords internal
 #' @noRd
-.sem_sample_descriptors_get <- function() {
+.sem_pivot_aggregate <- function(pivot, aggregation) {
 
-  ssEnv <- core_get_session_info()
-
-  pivot_path <- io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE", "WHOLE")
-  if (!file.exists(pivot_path)) {
-    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
-              " SIGNAL pivot not found, signal descriptors skipped: ", pivot_path)
-    return(NULL)
+  if (aggregation %in% c("SUM", "MEAN")) {
+    reduced <- if (identical(aggregation, "SUM")) pivot$sum() else pivot$mean()
+    reduced <- reduced$with_columns(polars::pl$col("*"))
+    out <- as.data.frame(t(as.data.frame(reduced$collect())))
+    # A pivot with no row after the mask reduces to NA on MEAN and 0 on SUM;
+    # both are honest answers to "no position in this scope".
+    return(out)
   }
 
-  lazy <- polars::pl$scan_parquet(pivot_path)
-  # The probe identifier column is named AREA in the PROBE pivot
-  # (io_signal_save()); every other column is a sample.
-  samples <- setdiff(names(lazy$collect_schema()), c("AREA", "PROBE", "CHR", "START", "END"))
-  if (length(samples) == 0) {
-    core_log_event("WARNING: ", format(Sys.time(), "%a %b %d %X %Y"),
-              " SIGNAL pivot carries no sample column; descriptors skipped.")
-    return(NULL)
-  }
-
-  beta  <- isTRUE(ssEnv$beta)
-  stats_wanted <- io_signal_stats(beta)
-  colnames_out <- vapply(stats_wanted, function(s) io_stat_colname("SAMPLE", s),
-                         character(1))
-
-  core_log_event("INFO: ", format(Sys.time(), "%a %b %d %X %Y"),
-            " Computing signal descriptors for ", length(samples),
-            " samples (scale: ", if (beta) "beta" else "M-value", ").")
-
-  s <- NULL   # quiet R CMD check note
-  descriptors <- foreach::foreach(
-    s         = seq_along(samples),
-    .combine  = rbind,
-    .packages = c("SEMseeker", "polars", "stats"),
-    .export   = c("samples", "pivot_path", "beta", "stats_wanted", "colnames_out")
-  ) %dorng% tryCatch({
-    sample_id <- samples[s]
-    values <- as.data.frame(
-      polars::pl$scan_parquet(pivot_path)$select(sample_id)$collect()
-    )[[1]]
-    values <- as.numeric(values)
-    values <- values[is.finite(values)]
-
-    row <- SEMseeker:::util_signal_descriptors(values, beta = beta)
-    out <- data.frame(Sample_ID = sample_id, stringsAsFactors = FALSE)
-    for (i in seq_along(stats_wanted)) {
-      # NULL would DROP the column instead of filling it, and rows of unequal
-      # width break the rbind combine.
-      value <- row[[stats_wanted[i]]]
-      out[[colnames_out[i]]] <- if (is.null(value)) NA_real_ else value
-    }
-    out
-  }, error = function(e) {
-    NULL
-  })
-
-  if (is.null(descriptors) || nrow(descriptors) == 0)
+  samples <- names(pivot$collect_schema())
+  if (length(samples) == 0)
     return(NULL)
 
-  rownames(descriptors) <- NULL
-  descriptors
+  collected <- as.data.frame(pivot$collect())
+  out <- data.frame(value = vapply(samples, function(s)
+    as.numeric(util_aggregate_values(collected[[s]], aggregation)),
+    numeric(1)), stringsAsFactors = FALSE)
+  rownames(out) <- samples
+  out
 }

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -213,19 +213,6 @@ sem_sample_stats_build <- function() {
     return(NULL)
   }
 
-  # SIGNAL is not an analysis you opt into: it is the data the run was given,
-  # and its descriptors — plus N_PROBES, which is metadata of the scope and not
-  # of any marker — must be there whatever `markers` was restricted to. Before
-  # AI-248 they came from a separate path that read the signal pivot directly;
-  # now they travel through the keys, so the key has to be there.
-  if (!any(keys$MARKER == "SIGNAL")) {
-    signal_key <- keys[1, , drop = FALSE]
-    signal_key$MARKER   <- "SIGNAL"
-    signal_key$FIGURE   <- io_signal_figure()
-    signal_key$DISCRETE <- FALSE
-    keys <- rbind(keys, signal_key)
-  }
-
   scope <- io_scope_name(area = area, subarea = subarea)
   mask  <- if (identical(scope, "SAMPLE")) NULL else .sem_scope_probe_mask(area, subarea)
   if (!identical(scope, "SAMPLE") && is.null(mask)) {
@@ -261,12 +248,6 @@ sem_sample_stats_build <- function() {
     aggregations <- util_aggregations_allowed(marker, figure,
                                               discrete = isTRUE(key$DISCRETE),
                                               default  = TRUE)
-    # The number of usable positions is a property of the SCOPE, not an
-    # aggregation of a marker, so it carries no marker/figure in its name. It is
-    # read off the signal, which is the only marker present at every position.
-    if (identical(marker, "SIGNAL"))
-      aggregations <- c(aggregations, "N_PROBES")
-
     for (aggregation in aggregations) {
       values <- .sem_pivot_aggregate(pivot, aggregation)
       if (is.null(values))
@@ -287,11 +268,53 @@ sem_sample_stats_build <- function() {
     }
   }
 
+  # The number of usable positions is a property of the SCOPE, not of any
+  # marker: it is the denominator that makes every other column readable, and
+  # the density is defined on it. It is therefore computed whatever `markers`
+  # asked for — reading the signal pivot to count positions is not the same as
+  # producing the signal's own columns, which follow `markers` like every other
+  # marker's do.
+  n_probes <- .sem_scope_n_probes(mask)
+  if (!is.null(n_probes)) {
+    colnames(n_probes) <- io_feature_colname(scope, aggregation = "N_PROBES")
+    n_probes$Sample_ID <- rownames(n_probes)
+    rownames(n_probes) <- NULL
+    result <- if (is.null(result)) n_probes else
+      merge(result, n_probes, by = "Sample_ID", all = TRUE)
+  }
+
   if (is.null(result))
     return(NULL)
 
   rownames(result) <- NULL
   result
+}
+
+#' Positions of a scope that carry a usable value, per sample (internal)
+#'
+#' AI-248. Read off the signal pivot, which is the one matrix defined at every
+#' eligible position, and independently of the `markers` the run asked for.
+#'
+#' @param mask scope mask, or `NULL` for the whole sample.
+#' @keywords internal
+#' @noRd
+.sem_scope_n_probes <- function(mask) {
+
+  pivot <- io_read_pivot("SIGNAL", io_signal_figure(), "POSITION", "WHOLE")
+  if (is.null(pivot))
+    return(NULL)
+
+  if (!is.null(mask)) {
+    pivot <- pivot$with_columns(
+      polars::pl$col("CHR")$cast(polars::pl$String)$str$replace("^(?i)chr", ""),
+      polars::pl$col("START")$cast(polars::pl$Int32),
+      polars::pl$col("END")$cast(polars::pl$Int32)
+    )
+    pivot <- pivot$join(mask, on = c("CHR", "START", "END"), how = "semi")
+  }
+  pivot <- pivot$drop(c("CHR", "START", "END"))
+
+  .sem_pivot_aggregate(pivot, "N_PROBES")
 }
 
 #' Reduce every sample column of a pivot with one aggregation (internal)

--- a/R/sem_sample_stats.R
+++ b/R/sem_sample_stats.R
@@ -213,6 +213,19 @@ sem_sample_stats_build <- function() {
     return(NULL)
   }
 
+  # SIGNAL is not an analysis you opt into: it is the data the run was given,
+  # and its descriptors — plus N_PROBES, which is metadata of the scope and not
+  # of any marker — must be there whatever `markers` was restricted to. Before
+  # AI-248 they came from a separate path that read the signal pivot directly;
+  # now they travel through the keys, so the key has to be there.
+  if (!any(keys$MARKER == "SIGNAL")) {
+    signal_key <- keys[1, , drop = FALSE]
+    signal_key$MARKER   <- "SIGNAL"
+    signal_key$FIGURE   <- io_signal_figure()
+    signal_key$DISCRETE <- FALSE
+    keys <- rbind(keys, signal_key)
+  }
+
   scope <- io_scope_name(area = area, subarea = subarea)
   mask  <- if (identical(scope, "SAMPLE")) NULL else .sem_scope_probe_mask(area, subarea)
   if (!identical(scope, "SAMPLE") && is.null(mask)) {

--- a/R/sem_signal_single_sample.R
+++ b/R/sem_signal_single_sample.R
@@ -10,7 +10,10 @@ sem_signal_single_sample <- function(values,sample_detail,probe_features)
 {
   ssEnv <- core_get_session_info()
 
-  folder_to_save <- io_dir_check_and_create(ssEnv$result_folderData, c(sample_detail$Sample_Group ,paste0("SIGNAL","_", "MEAN", sep = "")))
+  # AI-248: the per-sample folder is named after the (marker, figure) key, and
+  # the figure of SIGNAL is the scale — it must agree with io_bed_file_name()
+  # and with io_list_bed_files_for_marker_figure(), which rebuild the same name.
+  folder_to_save <- io_dir_check_and_create(ssEnv$result_folderData, c(sample_detail$Sample_Group ,paste0("SIGNAL","_", io_signal_figure(), sep = "")))
   # DEBUG (2026-06-09): right before the data.frame() that has
   # been exploding with "arguments imply differing number of rows" since
   # v35. Inspect:
@@ -21,6 +24,6 @@ sem_signal_single_sample <- function(values,sample_detail,probe_features)
   signal_values_annotated <- data.frame(as.data.frame(probe_features), "VALUE" = values, row.names = probe_features$PROBE)[, c("CHR", "START", "END","VALUE")]
   io_dump_sample_as_bed_file(
     data_to_dump = signal_values_annotated,
-    fileName = io_file_path_build(baseFolder =  folder_to_save, detailsFilename =  c(sample_detail$Sample_ID,"SIGNAL","MEAN"), extension = "bedgraph", add_gz=TRUE)
+    fileName = io_file_path_build(baseFolder =  folder_to_save, detailsFilename =  c(sample_detail$Sample_ID,"SIGNAL", io_signal_figure()), extension = "bedgraph", add_gz=TRUE)
   )
 }

--- a/R/util_aggregate_values.R
+++ b/R/util_aggregate_values.R
@@ -1,0 +1,44 @@
+#' Reduce a set of values to one number, by aggregation name (internal)
+#'
+#' AI-248. The other half of the AGGREGATION axis: [util_aggregations_allowed()]
+#' declares which names are legal, this one is the only place that says what each
+#' name *computes*. Keeping the two together in one vocabulary is what stops a
+#' column called `MEDIAN` from holding a mean.
+#'
+#' `MODE_LOW` / `MODE_HIGH` are the only distribution-shape operators: they
+#' estimate the highest density peak on each side of 0.5, so they need the whole
+#' distribution rather than a streaming reduce, and they are admissible only on
+#' the bounded scale. They delegate to [util_signal_descriptors()], which already
+#' implements the estimate.
+#'
+#' @param values numeric vector. Non-finite values are dropped.
+#' @param aggregation one name from [util_aggregations_allowed()], or
+#'   `"N_PROBES"` for the count of usable positions.
+#' @return a single numeric, `NA_real_` when the values do not support it.
+#' @keywords internal
+#' @noRd
+util_aggregate_values <- function(values, aggregation) {
+
+  aggregation <- toupper(as.character(aggregation))
+  values <- as.numeric(values)
+  values <- values[is.finite(values)]
+
+  if (identical(aggregation, "N_PROBES"))
+    return(length(values))
+
+  if (length(values) == 0L)
+    return(NA_real_)
+
+  switch(
+    aggregation,
+    SUM       = sum(values),
+    MEAN      = mean(values),
+    MEDIAN    = stats::median(values),
+    VARIANCE  = stats::var(values),
+    IQR       = stats::IQR(values),
+    MODE_LOW  = util_signal_descriptors(values, beta = TRUE)$MODE_LOW,
+    MODE_HIGH = util_signal_descriptors(values, beta = TRUE)$MODE_HIGH,
+    stop("util_aggregate_values(): unknown aggregation '", aggregation,
+         "'. Legal names come from util_aggregations_allowed().")
+  )
+}

--- a/R/util_aggregation_vocabulary.R
+++ b/R/util_aggregation_vocabulary.R
@@ -1,0 +1,31 @@
+#' Every aggregation name the taxonomy knows (internal)
+#'
+#' AI-248. The full vocabulary of the AGGREGATION axis, independent of any
+#' marker: the union of what [util_aggregations_allowed()] admits over both
+#' classes of marker, counts and continuous values.
+#'
+#' This answers a different question from `util_aggregations_allowed()`, and
+#' the two must not be confused. This one is a **spell-check**: is the string
+#' the caller wrote the name of an aggregation at all, or a typo? The other one
+#' is the **semantic** check: is this operator meaningful for *this*
+#' `(MARKER, FIGURE)`. A validator needs both, in that order — a helpful error
+#' for `"MEDAIN"` ("not a name we know") is not the same as the error for
+#' `MODE_LOW` on M-values ("a real name, wrong scale").
+#'
+#' It exists as its own function because the callers used to obtain the union by
+#' asking `util_aggregations_allowed("SIGNAL", "BETA", ...)` — the one pair that
+#' happens to admit everything. That worked, but it read as an assumption about
+#' the scale of the session, which it never was: a reader on an `MVALUE` run had
+#' every reason to think it was a bug.
+#'
+#' @return character vector of aggregation names.
+#' @keywords internal
+#' @noRd
+util_aggregation_vocabulary <- function() {
+  # The union over both classes. SIGNAL/BETA is what widens the set — it is the
+  # only combination carrying MODE_LOW/MODE_HIGH — but here it names the axis,
+  # not the run: the vocabulary of a language does not depend on the sentence.
+  unique(unlist(lapply(c(TRUE, FALSE), function(discrete)
+    util_aggregations_allowed("SIGNAL", "BETA", discrete = discrete,
+                              default = FALSE))))
+}

--- a/R/util_aggregations_allowed.R
+++ b/R/util_aggregations_allowed.R
@@ -36,23 +36,38 @@ util_aggregations_allowed <- function(marker, figure = NULL, discrete = TRUE,
   marker <- toupper(as.character(marker))
   figure <- if (is.null(figure)) "" else toupper(as.character(figure))
 
-  is_signal <- identical(marker, "SIGNAL")
-  bounded   <- is_signal && identical(figure, "BETA")
+  # Two classes, and the class is what decides. SIGNAL, DELTAS and DELTAR are
+  # all continuous — a value per position — and take the same operators; the
+  # instability markers are counts, 0 or 1 per position.
+  # SIGNAL is continuous by definition, whatever the caller passes: the raw
+  # signal is never a count.
+  if (identical(marker, "SIGNAL"))
+    discrete <- FALSE
+  bounded <- identical(marker, "SIGNAL") && identical(figure, "BETA")
 
-  every <- c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR")
+  if (isTRUE(discrete)) {
+    # SUM is the burden. MEAN of a 0/1 vector is the same burden divided by the
+    # positions of the scope, i.e. the DENSITY of epimutations — the only form
+    # comparable across regions of different size, which a raw burden is not.
+    # MEDIAN, VARIANCE and IQR of a 0/1 vector are degenerate, so they are not
+    # admissible: naming them would only add noise to the file.
+    admissible <- c("SUM", "MEAN")
+    return(if (isTRUE(default)) "SUM" else admissible)
+  }
+
+  admissible <- c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR")
+  # The two modes look for the highest density peak on EACH SIDE OF 0.5, which
+  # presupposes a scale bounded in [0,1] and bimodal. DELTAS and DELTAR are
+  # deviations centred on zero: that split says nothing about them.
   if (bounded)
-    every <- c(every, "MODE_LOW", "MODE_HIGH")
+    admissible <- c(admissible, "MODE_LOW", "MODE_HIGH")
 
   if (!isTRUE(default))
-    return(every)
+    return(admissible)
 
-  # Produced by default: the operator that carries the meaning of the marker.
-  # For the raw signal there is no privileged operator, so the whole descriptor
-  # set is produced. For everything else the default is the operator the package
-  # has always applied — a count of epimutations is a burden and the burden is
-  # its sum, a continuous deviation is averaged.
-  if (is_signal)
-    return(setdiff(every, "SUM"))
-
-  if (isTRUE(discrete)) "SUM" else "MEAN"
+  # Every continuous marker is produced with the whole descriptor set: no
+  # operator is privileged for a continuous value. This ADDS columns without
+  # changing any existing number — the historical mean keeps its value and
+  # merely gains the _MEAN suffix.
+  setdiff(admissible, "SUM")
 }

--- a/R/util_aggregations_allowed.R
+++ b/R/util_aggregations_allowed.R
@@ -1,0 +1,58 @@
+#' Aggregations admissible for a marker/figure pair (internal)
+#'
+#' AI-248. Single source of truth of the AGGREGATION axis: which ways of
+#' reducing a set of positions to one number are admissible for a given
+#' `(MARKER, FIGURE)`. The producer iterates over this to know what to compute,
+#' the consumer validates against it, and [io_feature_colname()] names the
+#' result — so the computed keys and the declared vocabulary cannot drift apart.
+#'
+#' The axis is **permissive by design**: every aggregation applies to every
+#' marker. Whether the median of hypermethylated mutations *means* something is
+#' a question for the biologist reading the table; making it expressible and
+#' nameable in a uniform way is the package's job. This generalises the old
+#' binary `DISCRETE` flag, which could only say "sum" or "mean".
+#'
+#' One restriction, and it is not arbitrary: `MODE_LOW` / `MODE_HIGH` estimate
+#' the two peaks of a bimodal distribution on a bounded scale, which only exists
+#' for `SIGNAL` on the `BETA` scale. On M-values the distribution is unimodal and
+#' the split carries no meaning.
+#'
+#' @param marker,figure the pair. `figure` matters only for `SIGNAL`, where it
+#'   carries the scale (see [io_signal_figure()]).
+#' @param discrete the `DISCRETE` flag of the key. It no longer decides the
+#'   operator — that is the point of this axis — but it still says which
+#'   aggregation is produced **by default** for a marker that is not `SIGNAL`:
+#'   a count is summed, a continuous deviation is averaged. Preserving that
+#'   distinction is what keeps the migration from silently changing the numbers
+#'   of the DELTA family.
+#' @param default when `TRUE` (default) return only what is produced without
+#'   being asked. When `FALSE` return everything the taxonomy admits.
+#' @return character vector of aggregation names.
+#' @keywords internal
+#' @noRd
+util_aggregations_allowed <- function(marker, figure = NULL, discrete = TRUE,
+                                      default = TRUE) {
+
+  marker <- toupper(as.character(marker))
+  figure <- if (is.null(figure)) "" else toupper(as.character(figure))
+
+  is_signal <- identical(marker, "SIGNAL")
+  bounded   <- is_signal && identical(figure, "BETA")
+
+  every <- c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR")
+  if (bounded)
+    every <- c(every, "MODE_LOW", "MODE_HIGH")
+
+  if (!isTRUE(default))
+    return(every)
+
+  # Produced by default: the operator that carries the meaning of the marker.
+  # For the raw signal there is no privileged operator, so the whole descriptor
+  # set is produced. For everything else the default is the operator the package
+  # has always applied — a count of epimutations is a burden and the burden is
+  # its sum, a continuous deviation is averaged.
+  if (is_signal)
+    return(setdiff(every, "SUM"))
+
+  if (isTRUE(discrete)) "SUM" else "MEAN"
+}

--- a/R/util_keys_create.R
+++ b/R/util_keys_create.R
@@ -31,7 +31,12 @@ util_keys_create <- function(ssEnv, arguments)
   keys_markers_figures_default_continuos <- merge(keys_markers_default_continuos, keys_figures_default_continuos, by = NULL)
   rm(keys_figures_default_continuos, keys_markers_default_continuos)
 
-  keys_figures_default_continuos_mono_figure <-  data.frame("FIGURE"=c("MEAN"))
+  # AI-248: the figure of SIGNAL is the SCALE of the value (BETA / MVALUE), not
+  # a way of aggregating it — "MEAN" used to sit here as a placeholder that made
+  # the key unique. The scale is unknown at init (no data read yet), so this is
+  # the bounded default; core_get_meth_tech() realigns it via
+  # util_keys_signal_figure_refresh() as soon as the first batch is seen.
+  keys_figures_default_continuos_mono_figure <-  data.frame("FIGURE"=c(io_signal_figure()))
   keys_markers_default_continuos_mono_figure <-  data.frame("MARKER"=c("SIGNAL"))
   keys_markers_default_continuos_mono_figure$SUFFIX <-  c("")
   # keys_markers_default$SUFFIX <-  c("","","","", ssEnv$epiquantile ,"",ssEnv$epiquantile)

--- a/R/util_keys_signal_figure_refresh.R
+++ b/R/util_keys_signal_figure_refresh.R
@@ -1,0 +1,49 @@
+#' Realign the SIGNAL keys to the scale of the data (internal)
+#'
+#' AI-248. The figure of `SIGNAL` is the scale of the value (`BETA` / `MVALUE`,
+#' see [io_signal_figure()]), but the keys are built by `util_keys_create()`
+#' inside `core_init_env()`, before any data has been read — at that point the
+#' scale is unknown and the bounded one is assumed.
+#'
+#' `core_get_meth_tech()` determines the scale on the first batch and calls this
+#' to realign the stored keys. Without it an M-value run would carry `SIGNAL`
+#' keys labelled `BETA` for its whole life, and would write pivots whose name
+#' claims a scale the values do not have.
+#'
+#' Idempotent: on a beta run, or on a resumed session where the keys are already
+#' aligned, it changes nothing.
+#'
+#' @param ssEnv session environment, already carrying `beta`.
+#' @return the session environment, with the SIGNAL keys realigned.
+#' @keywords internal
+#' @noRd
+util_keys_signal_figure_refresh <- function(ssEnv) {
+
+  figure <- io_signal_figure(ssEnv$beta)
+  stale  <- c("MEAN", setdiff(c("BETA", "MVALUE"), figure))
+
+  realign <- function(keys) {
+    if (is.null(keys) || !all(c("MARKER", "FIGURE") %in% colnames(keys)))
+      return(keys)
+    target <- keys$MARKER == "SIGNAL" & keys$FIGURE %in% stale
+    if (!any(target))
+      return(keys)
+    keys$FIGURE[target] <- figure
+    if ("COMBINED" %in% colnames(keys)) {
+      cols <- intersect(c("MARKER", "FIGURE", "AREA", "SUBAREA"), colnames(keys))
+      keys$COMBINED[target] <- apply(keys[target, cols, drop = FALSE], 1, function(x)
+        core_name_cleaning(gsub(" ", "", paste0(x[x != ""], collapse = "_"))))
+    }
+    keys
+  }
+
+  for (key_set in c("keys_markers_figures", "keys_areas_subareas_markers_figures",
+                    "keys_markers_figures_default"))
+    ssEnv[[key_set]] <- realign(ssEnv[[key_set]])
+
+  if (!is.null(ssEnv$default$keys_markers_figures_default))
+    ssEnv$default$keys_markers_figures_default <-
+      realign(ssEnv$default$keys_markers_figures_default)
+
+  ssEnv
+}

--- a/man/association_analysis.Rd
+++ b/man/association_analysis.Rd
@@ -33,6 +33,17 @@ Required columns:
   \item{depth_analysis}{Integer depth: \code{1} = sample level,
     \code{2} = type level (gene, DMR, CpG island),
     \code{3} = genomic area (TSS1550, WHOLE, TSS200, …).}
+  \item{aggregation}{Required. How the positions are reduced to the one
+    number the model is fitted on: \code{"SUM"}, \code{"MEAN"},
+    \code{"MEDIAN"}, \code{"VARIANCE"}, \code{"IQR"}, \code{"MODE_LOW"} or
+    \code{"MODE_HIGH"}. While every marker admitted exactly one operator
+    this could stay implicit; a scope now carries several, so the request
+    has to name the one it wants. Which are admissible depends on the
+    marker: a count carries \code{SUM} (the burden) and \code{MEAN} (the
+    density, the form comparable across regions of different size), while
+    its median and IQR are degenerate; the two modes exist only for the
+    signal on the beta scale. A request no marker of the run admits is
+    dropped with a warning naming it, not answered with an empty result.}
   \item{scopes}{Optional, depth=1 only. Which scopes of
     \code{SAMPLE_STATS_RESULT.csv} to test, several separated by
     \code{"+"} (default \code{"SAMPLE"}). A region scope such as

--- a/man/sem_coverage_analysis_report.Rd
+++ b/man/sem_coverage_analysis_report.Rd
@@ -13,9 +13,11 @@ sem_coverage_analysis_report(
 )
 }
 \arguments{
-\item{signal_data}{character. Path to the signal parquet file (e.g.
-\code{Data/SIGNAL_MEAN_PROBE_WHOLE.parquet}) or a data.frame already
-loaded into memory.}
+\item{signal_data}{character. Path to the signal parquet file under
+\code{Data/Pivots/SIGNAL/}, or a data.frame already loaded into memory.
+The file is named \code{SIGNAL_<FIGURE>_PROBE_WHOLE_<GENOME_BUILD>.parquet},
+where \code{FIGURE} is the scale the run was written on — \code{BETA} for a
+proportion bounded in [0,1], \code{MVALUE} for the logit-transformed one.}
 
 \item{result_folder}{character. Path to the SEMseeker result folder.}
 
@@ -40,8 +42,10 @@ Generate a coverage analysis report for Illumina methylation
 \examples{
 result_dir <- tempdir()
 \dontrun{
+# BETA is the scale this particular run was written on; a run on the
+# logit scale produces SIGNAL_MVALUE_PROBE_WHOLE_HG19.parquet instead.
 sem_coverage_analysis_report(
-  signal_data   = "~/semseeker_results/Data/SIGNAL_MEAN_PROBE_WHOLE.parquet",
+  signal_data   = "~/semseeker_results/Data/Pivots/SIGNAL/SIGNAL_BETA_PROBE_WHOLE_HG19.parquet",
   result_folder = "~/semseeker_results/"
 )
 }

--- a/tests/testthat/helper-burden.R
+++ b/tests/testthat/helper-burden.R
@@ -43,6 +43,13 @@
 # AI-223: the burden lives in the statistics sibling under the SAMPLE scope,
 # so the column names carry the scope prefix. Composed here the same way
 # io_burden_colname() composes them on the package side.
-.burden_cols <- paste0("SAMPLE_",
-                       c(paste0(.burden_required_markers, "_HYPER"),
-                         paste0(.burden_required_markers, "_HYPO")))
+# AI-248: the name carries the aggregation, and which one is produced by
+# default depends on the class of the marker — a count is summed, a continuous
+# deviation carries the descriptor set (of which MEAN is the historical value).
+.burden_discrete_markers   <- c("MUTATIONS", "DELTAP", "DELTAQ", "DELTARP", "DELTARQ")
+.burden_continuous_markers <- c("DELTAS", "DELTAR")
+.burden_cols <- c(
+  paste0("SAMPLE_", c(paste0(.burden_discrete_markers, "_HYPER"),
+                      paste0(.burden_discrete_markers, "_HYPO")), "_SUM"),
+  paste0("SAMPLE_", c(paste0(.burden_continuous_markers, "_HYPER"),
+                      paste0(.burden_continuous_markers, "_HYPO")), "_MEAN"))

--- a/tests/testthat/test-0-analyze_population_bulk.R
+++ b/tests/testthat/test-0-analyze_population_bulk.R
@@ -39,7 +39,10 @@ test_that("sem_analyze_population_bulk - synthetic 10x5 produces correct pivots"
     stringsAsFactors = FALSE
   )
 
-  signal_path <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", "MEAN",
+  # The FIGURE of SIGNAL is the scale of the session, resolved by the same
+  # function sem_analyze_population_bulk() uses to look this pivot up.
+  signal_path <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL",
+                                                    SEMseeker:::io_signal_figure(),
                                                     "POSITION", "WHOLE")
   dir.create(dirname(signal_path), recursive = TRUE, showWarnings = FALSE)
   polars::as_polars_df(probe_df)$write_parquet(signal_path)

--- a/tests/testthat/test-0-sample-stats-sibling.R
+++ b/tests/testthat/test-0-sample-stats-sibling.R
@@ -35,27 +35,6 @@ test_that("io_scope_name derives the scope from (area, subarea) with no depth", 
   expect_equal(SEMseeker:::io_scope_name(area = "", subarea = "TSS1500"), "SAMPLE")
 })
 
-test_that("io_stat_colname and io_burden_colname compose the documented names", {
-  expect_equal(SEMseeker:::io_stat_colname("SAMPLE", "MEDIAN"), "SAMPLE_MEDIAN")
-  expect_equal(SEMseeker:::io_stat_colname("GENE_BODY", "IQR"), "GENE_BODY_IQR")
-  expect_equal(
-    SEMseeker:::io_burden_colname("SAMPLE", "MUTATIONS", "HYPER"),
-    "SAMPLE_MUTATIONS_HYPER")
-  expect_equal(
-    SEMseeker:::io_burden_colname("GENE_BODY", "LESIONS", "HYPO"),
-    "GENE_BODY_LESIONS_HYPO")
-  # a scope is mandatory: an unscoped column would be ambiguous in the file
-  expect_error(SEMseeker:::io_stat_colname("", "MEDIAN"), "scope")
-  expect_error(SEMseeker:::io_burden_colname("", "MUTATIONS", "HYPER"), "scope")
-})
-
-test_that("io_signal_stats drops the two modes off the beta scale", {
-  expect_true(all(c("MODE_LOW", "MODE_HIGH") %in% SEMseeker:::io_signal_stats(beta = TRUE)))
-  expect_false(any(c("MODE_LOW", "MODE_HIGH") %in% SEMseeker:::io_signal_stats(beta = FALSE)))
-  expect_true(all(c("MEDIAN", "MEAN", "VARIANCE", "IQR", "N_PROBES") %in%
-                    SEMseeker:::io_signal_stats(beta = FALSE)))
-})
-
 # ---------------------------------------------------------------------------
 # descriptors (pure)
 # ---------------------------------------------------------------------------
@@ -138,12 +117,17 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
   # one row per sample of the signal matrix
   expect_equal(nrow(stats), ncol(syn$signal))
 
-  descriptor_cols <- c("SAMPLE_MEDIAN", "SAMPLE_MEAN", "SAMPLE_VARIANCE",
-                       "SAMPLE_IQR", "SAMPLE_N_PROBES",
-                       "SAMPLE_MODE_LOW", "SAMPLE_MODE_HIGH")
-  burden_cols <- c("SAMPLE_MUTATIONS_HYPER", "SAMPLE_MUTATIONS_HYPO",
-                   "SAMPLE_DELTAP_HYPER", "SAMPLE_DELTAP_HYPO",
-                   "SAMPLE_DELTAS_HYPER", "SAMPLE_DELTAS_HYPO")
+  # AI-248: SIGNAL is a marker like the others, its figure is the scale, and
+  # the operator is named. N_PROBES stays scope-level: no marker, no figure.
+  descriptor_cols <- c(
+    vapply(c("MEDIAN", "MEAN", "VARIANCE", "IQR", "MODE_LOW", "MODE_HIGH"),
+           function(a) SEMseeker:::io_feature_colname("SAMPLE", "SIGNAL", "BETA", a),
+           character(1)),
+    "SAMPLE_N_PROBES")
+  burden_cols <- c(
+    SEMseeker:::io_feature_colname("SAMPLE", "MUTATIONS", c("HYPER", "HYPO"), "SUM"),
+    SEMseeker:::io_feature_colname("SAMPLE", "DELTAP", c("HYPER", "HYPO"), "SUM"),
+    SEMseeker:::io_feature_colname("SAMPLE", "DELTAS", c("HYPER", "HYPO"), "MEAN"))
   expect_true(all(descriptor_cols %in% colnames(stats)),
               info = paste("missing:",
                            paste(setdiff(descriptor_cols, colnames(stats)), collapse = ", ")))
@@ -153,11 +137,11 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
 
   # the fixture is on the beta scale: descriptors must be in range and the two
   # modes must sit on either side of 0.5
-  expect_true(all(stats$SAMPLE_MEDIAN >= 0 & stats$SAMPLE_MEDIAN <= 1))
-  expect_true(all(stats$SAMPLE_IQR >= 0))
+  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MEDIAN >= 0 & stats$SAMPLE_SIGNAL_BETA_MEDIAN <= 1))
+  expect_true(all(stats$SAMPLE_SIGNAL_BETA_IQR >= 0))
   expect_true(all(stats$SAMPLE_N_PROBES > 0))
-  expect_true(all(stats$SAMPLE_MODE_LOW < 0.5, na.rm = TRUE))
-  expect_true(all(stats$SAMPLE_MODE_HIGH >= 0.5, na.rm = TRUE))
+  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MODE_LOW < 0.5, na.rm = TRUE))
+  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MODE_HIGH >= 0.5, na.rm = TRUE))
 
   # AI-223 net move: the burden left the sample sheet
   moved_away <- c("MUTATIONS_HYPER", "MUTATIONS_HYPO", "DELTAS_HYPER",
@@ -174,7 +158,7 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
                             start_fresh = FALSE, showprogress = FALSE, verbosity = 1)
   joined <- SEMseeker:::sem_study_summary_get()
   expect_true(all(burden_cols %in% colnames(joined)))
-  expect_true("SAMPLE_MEDIAN" %in% colnames(joined))
+  expect_true("SAMPLE_SIGNAL_BETA_MEDIAN" %in% colnames(joined))
 })
 
 # ---------------------------------------------------------------------------
@@ -213,8 +197,8 @@ test_that("a region scope reaches the sibling and the depth=1 inference", {
   skip_if_not(file.exists(stats_csv), "downstream assertions need the sibling")
   stats <- utils::read.csv2(stats_csv, stringsAsFactors = FALSE)
 
-  scope_cols <- SEMseeker:::io_burden_colname(scope, "MUTATIONS", c("HYPER", "HYPO"))
-  whole_cols <- SEMseeker:::io_burden_colname("SAMPLE", "MUTATIONS", c("HYPER", "HYPO"))
+  scope_cols <- SEMseeker:::io_feature_colname(scope, "MUTATIONS", c("HYPER", "HYPO"), "SUM")
+  whole_cols <- SEMseeker:::io_feature_colname("SAMPLE", "MUTATIONS", c("HYPER", "HYPO"), "SUM")
   expect_true(all(scope_cols %in% colnames(stats)),
               info = paste("missing:",
                            paste(setdiff(scope_cols, colnames(stats)), collapse = ", ")))
@@ -245,7 +229,7 @@ test_that("a region scope reaches the sibling and the depth=1 inference", {
   sample_columns <- setdiff(colnames(masked), c("CHR", "START", "END"))
   expected <- colSums(masked[, sample_columns, drop = FALSE], na.rm = TRUE)
 
-  observed <- stats[[SEMseeker:::io_burden_colname(scope, "MUTATIONS", "HYPER")]]
+  observed <- stats[[SEMseeker:::io_feature_colname(scope, "MUTATIONS", "HYPER", "SUM")]]
   names(observed) <- stats$Sample_ID
   common <- intersect(names(expected), names(observed))
   expect_gt(length(common), 0)
@@ -265,6 +249,7 @@ test_that("a region scope reaches the sibling and the depth=1 inference", {
     transformation_x     = "",
     depth_analysis       = 1L,
     scopes               = paste("SAMPLE", scope, sep = "+"),
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )
@@ -340,6 +325,7 @@ test_that("an unproduced scope stops the analysis instead of testing nothing", {
     transformation_x     = "",
     depth_analysis       = 1L,
     scopes               = "GENE_TSS1500",
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )

--- a/tests/testthat/test-0-sample-stats-sibling.R
+++ b/tests/testthat/test-0-sample-stats-sibling.R
@@ -117,13 +117,14 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
   # one row per sample of the signal matrix
   expect_equal(nrow(stats), ncol(syn$signal))
 
-  # AI-248: SIGNAL is a marker like the others, its figure is the scale, and
-  # the operator is named. N_PROBES stays scope-level: no marker, no figure.
-  descriptor_cols <- c(
-    vapply(c("MEDIAN", "MEAN", "VARIANCE", "IQR", "MODE_LOW", "MODE_HIGH"),
-           function(a) SEMseeker:::io_feature_colname("SAMPLE", "SIGNAL", "BETA", a),
-           character(1)),
-    "SAMPLE_N_PROBES")
+  # AI-248: `markers` means one thing for every marker, SIGNAL included — this
+  # run did not ask for it, so its descriptors must NOT be there. N_PROBES is
+  # not a marker column: it is the size of the scope, the denominator of the
+  # density, and it is there regardless.
+  descriptor_cols <- "SAMPLE_N_PROBES"
+  signal_cols <- vapply(c("MEDIAN", "MEAN", "VARIANCE", "IQR", "MODE_LOW", "MODE_HIGH"),
+                        function(a) SEMseeker:::io_feature_colname("SAMPLE", "SIGNAL", "BETA", a),
+                        character(1))
   burden_cols <- c(
     SEMseeker:::io_feature_colname("SAMPLE", "MUTATIONS", c("HYPER", "HYPO"), "SUM"),
     SEMseeker:::io_feature_colname("SAMPLE", "DELTAP", c("HYPER", "HYPO"), "SUM"),
@@ -135,13 +136,9 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
               info = paste("missing:",
                            paste(setdiff(burden_cols, colnames(stats)), collapse = ", ")))
 
-  # the fixture is on the beta scale: descriptors must be in range and the two
-  # modes must sit on either side of 0.5
-  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MEDIAN >= 0 & stats$SAMPLE_SIGNAL_BETA_MEDIAN <= 1))
-  expect_true(all(stats$SAMPLE_SIGNAL_BETA_IQR >= 0))
+  # a marker that was not asked for produces no column
+  expect_equal(intersect(signal_cols, colnames(stats)), character(0))
   expect_true(all(stats$SAMPLE_N_PROBES > 0))
-  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MODE_LOW < 0.5, na.rm = TRUE))
-  expect_true(all(stats$SAMPLE_SIGNAL_BETA_MODE_HIGH >= 0.5, na.rm = TRUE))
 
   # AI-223 net move: the burden left the sample sheet
   moved_away <- c("MUTATIONS_HYPER", "MUTATIONS_HYPO", "DELTAS_HYPER",
@@ -158,7 +155,7 @@ test_that("semseeker() writes the statistics sibling and leaves the sample sheet
                             start_fresh = FALSE, showprogress = FALSE, verbosity = 1)
   joined <- SEMseeker:::sem_study_summary_get()
   expect_true(all(burden_cols %in% colnames(joined)))
-  expect_true("SAMPLE_SIGNAL_BETA_MEDIAN" %in% colnames(joined))
+  expect_true("SAMPLE_N_PROBES" %in% colnames(joined))
 })
 
 # ---------------------------------------------------------------------------
@@ -184,7 +181,7 @@ test_that("a region scope reaches the sibling and the depth=1 inference", {
     # POSITION pivots.
     areas               = c("POSITION", "GENE"),
     subareas            = c("WHOLE", "TSS1500"),
-    markers             = c("MUTATIONS"),
+    markers             = c("MUTATIONS", "SIGNAL"),
     sample_stats_scopes = c("SAMPLE", scope),
     start_fresh         = TRUE,
     inpute              = "median",
@@ -207,6 +204,16 @@ test_that("a region scope reaches the sibling and the depth=1 inference", {
   # a subset of the probes can only carry a subset of the burden
   for (i in seq_along(scope_cols))
     expect_true(all(stats[[scope_cols[i]]] <= stats[[whole_cols[i]]]))
+
+  # AI-248: asking for SIGNAL gives its descriptors on the scope too — this is
+  # the per-sample median restricted to a region class
+  scope_median <- SEMseeker:::io_feature_colname(scope, "SIGNAL", "BETA", "MEDIAN")
+  expect_true(scope_median %in% colnames(stats),
+              info = paste("missing:", scope_median))
+  expect_true(all(stats[[scope_median]] >= 0 & stats[[scope_median]] <= 1, na.rm = TRUE))
+  # the scope holds fewer positions than the whole sample
+  expect_true(all(stats[[SEMseeker:::io_feature_colname(scope, aggregation = "N_PROBES")]] <=
+                    stats$SAMPLE_N_PROBES))
 
   # ── the mask counts every position once ──────────────────────────────────
   SEMseeker:::core_init_env(result_folder = tempFolder, parallel_strategy = "sequential",

--- a/tests/testthat/test-0-signal_save.R
+++ b/tests/testthat/test-0-signal_save.R
@@ -9,11 +9,16 @@ test_that("signal-save",{
   SEMseeker:::core_get_meth_tech(signal_data)
   SEMseeker:::io_signal_save(signal_data,mySampleSheet,batch_id )
 
+  # The FIGURE of SIGNAL is the scale of the session, resolved by the same
+  # function the writer uses: the test follows BETA or MVALUE, it does not
+  # decide it.
+  figure <- SEMseeker:::io_signal_figure()
+
   # io_signal_save writes the probe-level parquet with subarea "WHOLE"
-  signal_file <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", "MEAN", "PROBE", "WHOLE")
+  signal_file <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", figure, "PROBE", "WHOLE")
   testthat::expect_true(file.exists(signal_file))
   # it also writes the position-level file
-  position_file <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", "MEAN", "POSITION", "WHOLE")
+  position_file <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", figure, "POSITION", "WHOLE")
   testthat::expect_true(file.exists(position_file))
 
 

--- a/tests/testthat/test-0-taxonomy.R
+++ b/tests/testthat/test-0-taxonomy.R
@@ -54,27 +54,40 @@ test_that("the two modes are admissible only on the bounded scale", {
                                                            default = FALSE)))
 })
 
-test_that("the axis is permissive: every aggregation applies to every marker", {
+test_that("a 0/1 marker admits only the two aggregations that carry information", {
   admissible <- SEMseeker:::util_aggregations_allowed("MUTATIONS", "HYPER",
-                                                      default = FALSE)
-  expect_true(all(c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR") %in% admissible))
+                                                      discrete = TRUE, default = FALSE)
+  # the burden, and the burden per position — the density, which is what makes
+  # regions of different size comparable
+  expect_setequal(admissible, c("SUM", "MEAN"))
+  # median / variance / IQR of a vector of zeros and ones are degenerate
+  expect_false(any(c("MEDIAN", "VARIANCE", "IQR") %in% admissible))
+})
+
+test_that("the continuous markers are one class: DELTAS and DELTAR match SIGNAL", {
+  signal <- SEMseeker:::util_aggregations_allowed("SIGNAL", "MVALUE",
+                                                  discrete = FALSE, default = FALSE)
+  deltas <- SEMseeker:::util_aggregations_allowed("DELTAS", "HYPER",
+                                                  discrete = FALSE, default = FALSE)
+  deltar <- SEMseeker:::util_aggregations_allowed("DELTAR", "HYPO",
+                                                  discrete = FALSE, default = FALSE)
+  expect_setequal(deltas, signal)
+  expect_setequal(deltar, signal)
+  expect_true(all(c("MEAN", "MEDIAN", "VARIANCE", "IQR") %in% deltas))
 })
 
 test_that("what is produced by default is narrower than what is admissible", {
   # a count of epimutations is a burden, and the burden is its sum
   expect_equal(SEMseeker:::util_aggregations_allowed("MUTATIONS", "HYPER"), "SUM")
-  # a continuous deviation is averaged — the DELTA family must keep the numbers
-  # it has always produced
-  expect_equal(SEMseeker:::util_aggregations_allowed("DELTAS", "HYPER",
-                                                     discrete = FALSE), "MEAN")
-  # the raw signal has no privileged operator, so it carries the descriptors
-  produced <- SEMseeker:::util_aggregations_allowed("SIGNAL", "BETA")
-  expect_true(all(c("MEAN", "MEDIAN", "VARIANCE", "IQR",
-                    "MODE_LOW", "MODE_HIGH") %in% produced))
-  expect_false("SUM" %in% produced)
-  expect_true(length(produced) <
-                length(SEMseeker:::util_aggregations_allowed("SIGNAL", "BETA",
-                                                             default = FALSE)))
+  # every continuous marker carries the whole descriptor set: adding them does
+  # not change the historical mean, it only gives it a suffix
+  for (marker in c("SIGNAL", "DELTAS", "DELTAR")) {
+    produced <- SEMseeker:::util_aggregations_allowed(marker, "HYPER",
+                                                      discrete = FALSE)
+    expect_true(all(c("MEAN", "MEDIAN", "VARIANCE", "IQR") %in% produced),
+                info = marker)
+    expect_false("SUM" %in% produced, info = marker)
+  }
 })
 
 # ---------------------------------------------------------------------------
@@ -155,4 +168,82 @@ test_that("the pivot name carries the aggregation, and the scale for SIGNAL", {
                                                      "POSITION", "WHOLE")
   expect_match(basename(position), "^MUTATIONS_HYPER_POSITION_WHOLE_HG19\\.parquet$",
                ignore.case = TRUE)
+})
+
+# ---------------------------------------------------------------------------
+# coherence of the request, checked at the door
+# ---------------------------------------------------------------------------
+
+.tax_keys <- function(...) {
+  k <- data.frame(..., stringsAsFactors = FALSE)
+  k
+}
+
+test_that("a request that names no aggregation is refused, at every depth", {
+  keys <- .tax_keys(MARKER = "MUTATIONS", FIGURE = "HYPER", DISCRETE = TRUE)
+  for (depth in c(1L, 2L, 3L)) {
+    details <- data.frame(independent_variable = "Phenotest", family_test = "spearman",
+                          depth_analysis = depth, aggregation = NA,
+                          stringsAsFactors = FALSE)
+    expect_error(SEMseeker:::assoc_validate_aggregation(details, keys), "required")
+  }
+})
+
+test_that("an aggregation outside the taxonomy is refused", {
+  keys <- .tax_keys(MARKER = "MUTATIONS", FIGURE = "HYPER", DISCRETE = TRUE)
+  details <- data.frame(independent_variable = "Phenotest", family_test = "spearman",
+                        depth_analysis = 1L, aggregation = "AVERAGE",
+                        stringsAsFactors = FALSE)
+  expect_error(SEMseeker:::assoc_validate_aggregation(details, keys),
+               "not an aggregation")
+})
+
+test_that("an impossible request drops its row instead of stopping the batch", {
+  keys <- .tax_keys(MARKER = c("MUTATIONS", "SIGNAL"),
+                    FIGURE = c("HYPER", "BETA"),
+                    DISCRETE = c(TRUE, FALSE))
+  details <- data.frame(
+    independent_variable = c("Phenotest", "Phenotest"),
+    family_test          = c("spearman", "spearman"),
+    depth_analysis       = c(1L, 1L),
+    # MODE_LOW exists only for SIGNAL/BETA, so the first row is possible;
+    # a run with only counts would make it impossible
+    aggregation          = c("MEDIAN", "SUM"),
+    stringsAsFactors = FALSE)
+
+  expect_warning(kept <- SEMseeker:::assoc_validate_aggregation(details, keys),
+                 "not admissible for MUTATIONS/HYPER")
+  # partially admissible: the row survives, the impossible pairs are skipped
+  expect_equal(nrow(kept), 2L)
+
+  # now the same median against counts only: nothing can be computed
+  counts_only <- .tax_keys(MARKER = "MUTATIONS", FIGURE = "HYPER", DISCRETE = TRUE)
+  one_row <- details[1, , drop = FALSE]
+  expect_error(
+    suppressWarnings(SEMseeker:::assoc_validate_aggregation(one_row, counts_only)),
+    "nothing left to analyse")
+})
+
+test_that("a batch keeps the rows it can run and drops the ones it cannot", {
+  keys <- .tax_keys(MARKER = "MUTATIONS", FIGURE = "HYPER", DISCRETE = TRUE)
+  details <- data.frame(
+    independent_variable = c("Phenotest", "Phenotest"),
+    family_test          = c("spearman", "spearman"),
+    depth_analysis       = c(1L, 1L),
+    aggregation          = c("MEDIAN", "SUM"),
+    stringsAsFactors = FALSE)
+
+  expect_warning(kept <- SEMseeker:::assoc_validate_aggregation(details, keys),
+                 "row 1")
+  expect_equal(nrow(kept), 1L)
+  expect_equal(kept$aggregation, "SUM")
+})
+
+test_that("a possible request passes silently", {
+  keys <- .tax_keys(MARKER = "MUTATIONS", FIGURE = "HYPER", DISCRETE = TRUE)
+  details <- data.frame(independent_variable = "Phenotest", family_test = "spearman",
+                        depth_analysis = 1L, aggregation = "SUM",
+                        stringsAsFactors = FALSE)
+  expect_silent(kept <- SEMseeker:::assoc_validate_aggregation(details, keys))
+  expect_equal(nrow(kept), 1L)
 })

--- a/tests/testthat/test-0-taxonomy.R
+++ b/tests/testthat/test-0-taxonomy.R
@@ -1,0 +1,158 @@
+## AI-248 — taxonomy SCOPE x MARKER x FIGURE x AGGREGATION.
+##
+## Contracts:
+##   1. exactly two compositors — one for column names (io_feature_colname),
+##      one for file names (io_pivot_file_name*); nothing else pastes names;
+##   2. the aggregation vocabulary is declared in one place and computed in one
+##      place, so a column called MEDIAN cannot hold a mean;
+##   3. the FIGURE of SIGNAL is the scale, not an aggregation.
+
+# ---------------------------------------------------------------------------
+# column names
+# ---------------------------------------------------------------------------
+
+test_that("io_feature_colname carries the four axes in order", {
+  expect_equal(
+    SEMseeker:::io_feature_colname("SAMPLE", "SIGNAL", "BETA", "MEDIAN"),
+    "SAMPLE_SIGNAL_BETA_MEDIAN")
+  expect_equal(
+    SEMseeker:::io_feature_colname("GENE_TSS1500", "MUTATIONS", "HYPER", "SUM"),
+    "GENE_TSS1500_MUTATIONS_HYPER_SUM")
+  expect_equal(
+    SEMseeker:::io_feature_colname("SAMPLE", "SIGNAL", "MVALUE", "IQR"),
+    "SAMPLE_SIGNAL_MVALUE_IQR")
+})
+
+test_that("io_feature_colname drops the axes that do not apply", {
+  # the number of positions is a property of the scope, not an aggregation of a
+  # marker: no marker, no figure
+  expect_equal(
+    SEMseeker:::io_feature_colname("SAMPLE", aggregation = "N_PROBES"),
+    "SAMPLE_N_PROBES")
+  expect_equal(
+    SEMseeker:::io_feature_colname("GENE_TSS1500", aggregation = "N_PROBES"),
+    "GENE_TSS1500_N_PROBES")
+  # a scope is mandatory: an unscoped column would be ambiguous in the file
+  expect_error(SEMseeker:::io_feature_colname(""), "scope")
+  expect_error(SEMseeker:::io_feature_colname(NULL), "scope")
+})
+
+# ---------------------------------------------------------------------------
+# the aggregation vocabulary
+# ---------------------------------------------------------------------------
+
+test_that("the two modes are admissible only on the bounded scale", {
+  admissible_beta <- SEMseeker:::util_aggregations_allowed("SIGNAL", "BETA",
+                                                           default = FALSE)
+  admissible_mval <- SEMseeker:::util_aggregations_allowed("SIGNAL", "MVALUE",
+                                                           default = FALSE)
+  expect_true(all(c("MODE_LOW", "MODE_HIGH") %in% admissible_beta))
+  expect_false(any(c("MODE_LOW", "MODE_HIGH") %in% admissible_mval))
+  # an unbounded marker has no bimodal split to speak of either
+  expect_false(any(c("MODE_LOW", "MODE_HIGH") %in%
+                     SEMseeker:::util_aggregations_allowed("MUTATIONS", "HYPER",
+                                                           default = FALSE)))
+})
+
+test_that("the axis is permissive: every aggregation applies to every marker", {
+  admissible <- SEMseeker:::util_aggregations_allowed("MUTATIONS", "HYPER",
+                                                      default = FALSE)
+  expect_true(all(c("SUM", "MEAN", "MEDIAN", "VARIANCE", "IQR") %in% admissible))
+})
+
+test_that("what is produced by default is narrower than what is admissible", {
+  # a count of epimutations is a burden, and the burden is its sum
+  expect_equal(SEMseeker:::util_aggregations_allowed("MUTATIONS", "HYPER"), "SUM")
+  # a continuous deviation is averaged — the DELTA family must keep the numbers
+  # it has always produced
+  expect_equal(SEMseeker:::util_aggregations_allowed("DELTAS", "HYPER",
+                                                     discrete = FALSE), "MEAN")
+  # the raw signal has no privileged operator, so it carries the descriptors
+  produced <- SEMseeker:::util_aggregations_allowed("SIGNAL", "BETA")
+  expect_true(all(c("MEAN", "MEDIAN", "VARIANCE", "IQR",
+                    "MODE_LOW", "MODE_HIGH") %in% produced))
+  expect_false("SUM" %in% produced)
+  expect_true(length(produced) <
+                length(SEMseeker:::util_aggregations_allowed("SIGNAL", "BETA",
+                                                             default = FALSE)))
+})
+
+# ---------------------------------------------------------------------------
+# what each aggregation computes
+# ---------------------------------------------------------------------------
+
+test_that("util_aggregate_values computes what the name says", {
+  set.seed(3L)
+  values <- stats::rnorm(500, mean = 2, sd = 3)
+
+  expect_equal(SEMseeker:::util_aggregate_values(values, "SUM"), sum(values))
+  expect_equal(SEMseeker:::util_aggregate_values(values, "MEAN"), mean(values))
+  expect_equal(SEMseeker:::util_aggregate_values(values, "MEDIAN"),
+               stats::median(values))
+  expect_equal(SEMseeker:::util_aggregate_values(values, "VARIANCE"),
+               stats::var(values))
+  expect_equal(SEMseeker:::util_aggregate_values(values, "IQR"), stats::IQR(values))
+  expect_equal(SEMseeker:::util_aggregate_values(values, "N_PROBES"), length(values))
+})
+
+test_that("util_aggregate_values finds the two peaks of a bimodal sample", {
+  set.seed(11L)
+  values <- c(stats::rbeta(3000, 2, 40), stats::rbeta(3000, 40, 2))
+  low  <- SEMseeker:::util_aggregate_values(values, "MODE_LOW")
+  high <- SEMseeker:::util_aggregate_values(values, "MODE_HIGH")
+  expect_lt(low, 0.5)
+  expect_gt(high, 0.5)
+})
+
+test_that("util_aggregate_values degrades instead of inventing a number", {
+  expect_true(is.na(SEMseeker:::util_aggregate_values(numeric(0), "MEDIAN")))
+  expect_equal(SEMseeker:::util_aggregate_values(numeric(0), "N_PROBES"), 0L)
+  # non-finite values are not data
+  expect_equal(SEMseeker:::util_aggregate_values(c(1, NA, Inf, 3), "N_PROBES"), 2L)
+  expect_error(SEMseeker:::util_aggregate_values(1:10, "AVERAGE"), "unknown aggregation")
+})
+
+# ---------------------------------------------------------------------------
+# the figure of SIGNAL is the scale
+# ---------------------------------------------------------------------------
+
+test_that("io_signal_figure reports the scale, not an aggregation", {
+  expect_equal(SEMseeker:::io_signal_figure(beta = TRUE), "BETA")
+  expect_equal(SEMseeker:::io_signal_figure(beta = FALSE), "MVALUE")
+  # a session that has not seen the data yet defaults to the bounded scale
+  expect_equal(SEMseeker:::io_signal_figure(beta = NA), "BETA")
+})
+
+# ---------------------------------------------------------------------------
+# file names
+# ---------------------------------------------------------------------------
+
+test_that("the pivot name carries the aggregation, and the scale for SIGNAL", {
+  tempFolder <- tempFolders[17]
+  unlink(tempFolder, recursive = TRUE)
+  on.exit({ try(SEMseeker:::core_close_env(), silent = TRUE)
+            unlink(tempFolder, recursive = TRUE) }, add = TRUE)
+
+  SEMseeker:::core_init_env(result_folder = tempFolder, parallel_strategy = "sequential",
+                            areas = c("POSITION"), markers = c("MUTATIONS"),
+                            start_fresh = TRUE, showprogress = FALSE, verbosity = 1)
+
+  burden <- SEMseeker:::io_pivot_file_name_parquet("MUTATIONS", "HYPER", "CHR",
+                                                   "CYTOBAND", aggregation = "SUM")
+  expect_match(basename(burden), "^MUTATIONS_HYPER_CHR_CYTOBAND_SUM_HG19\\.parquet$",
+               ignore.case = TRUE)
+
+  beta_mean <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", "BETA", "CHR",
+                                                      "CYTOBAND", aggregation = "MEAN")
+  mval_mean <- SEMseeker:::io_pivot_file_name_parquet("SIGNAL", "MVALUE", "CHR",
+                                                      "CYTOBAND", aggregation = "MEAN")
+  # the two scales must not overwrite each other in the same folder
+  expect_false(identical(beta_mean, mval_mean))
+
+  # omitting the aggregation is how the not-yet-aggregated POSITION pivots are
+  # named, and must keep the historical shape
+  position <- SEMseeker:::io_pivot_file_name_parquet("MUTATIONS", "HYPER",
+                                                     "POSITION", "WHOLE")
+  expect_match(basename(position), "^MUTATIONS_HYPER_POSITION_WHOLE_HG19\\.parquet$",
+               ignore.case = TRUE)
+})

--- a/tests/testthat/test-1-signal-coord.R
+++ b/tests/testthat/test-1-signal-coord.R
@@ -338,7 +338,10 @@ test_that("sem_signal_single_sample: writes bedgraph file for coordinate-format 
   )
 
   ssEnv       <- SEMseeker:::core_get_session_info()
-  folder      <- file.path(ssEnv$result_folderData, "Control", "SIGNAL_MEAN")
+  # The FIGURE of SIGNAL is the scale of the session, resolved by the same
+  # function the writer uses: the test follows BETA or MVALUE.
+  folder      <- file.path(ssEnv$result_folderData, "Control",
+                           paste0("SIGNAL_", SEMseeker:::io_signal_figure()))
   bed_files   <- list.files(folder, pattern = "\\.bedgraph(\\.gz)?$", recursive = TRUE)
   expect_gte(length(bed_files), 1L)
 })

--- a/tests/testthat/test-1-signal.R
+++ b/tests/testthat/test-1-signal.R
@@ -8,8 +8,13 @@ test_that("signal",{
 
   res <- SEMseeker:::sem_signal_single_sample(values = signal_data[,sample_detail$Sample_ID], sample_detail = sample_detail, probe_features = probe_features)
 
-  folder_to_save <- SEMseeker:::io_dir_check_and_create(ssEnv$result_folderData,c(sample_detail$Sample_Group,paste0("SIGNAL","_", "MEAN", sep = "")))
-  signal_file <- SEMseeker:::io_file_path_build(folder_to_save,c(sample_detail$Sample_ID,"SIGNAL","MEAN"),"bedgraph", add_gz = TRUE)
+  # The FIGURE of SIGNAL is the scale of the session, resolved by the same
+  # function the writer uses: the test follows BETA or MVALUE, it does not
+  # decide it.
+  figure <- SEMseeker:::io_signal_figure()
+
+  folder_to_save <- SEMseeker:::io_dir_check_and_create(ssEnv$result_folderData,c(sample_detail$Sample_Group,paste0("SIGNAL","_", figure, sep = "")))
+  signal_file <- SEMseeker:::io_file_path_build(folder_to_save,c(sample_detail$Sample_ID,"SIGNAL",figure),"bedgraph", add_gz = TRUE)
   testthat::expect_true(file.exists(signal_file))
 
   signal_file <- read.table(signal_file, sep="\t")

--- a/tests/testthat/test-7-association_analysis.R
+++ b/tests/testthat/test-7-association_analysis.R
@@ -162,6 +162,7 @@ test_that("association_analysis depth=1 gaussian runs without error and writes i
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 1L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )
@@ -253,6 +254,7 @@ test_that("association_analysis depth=3 reads area pivots and writes inference C
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 3L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )
@@ -312,6 +314,7 @@ test_that("association_analysis polynomial family runs without error", {
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 1L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )
@@ -351,6 +354,7 @@ test_that("association_analysis with covariates runs and produces a assoc_covari
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 1L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     collinearity_check   = TRUE,
     stringsAsFactors     = FALSE
@@ -391,6 +395,7 @@ test_that("association_analysis is idempotent: second run on same folder does no
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 1L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )
@@ -469,6 +474,7 @@ test_that("association_analysis skips gracefully when independent_variable absen
     transformation_y     = "",
     transformation_x     = "",
     depth_analysis       = 1L,
+    aggregation          = "SUM",
     filter_p_value       = FALSE,
     stringsAsFactors     = FALSE
   )

--- a/tests/testthat/test-8-burden-integration.R
+++ b/tests/testthat/test-8-burden-integration.R
@@ -87,10 +87,9 @@ test_that("sample_sheet_result.csv has populated burden columns for all discrete
   required_markers <- c("MUTATIONS",
                         "DELTAP", "DELTAQ", "DELTARP", "DELTARQ",
                         "DELTAS", "DELTAR")
-  required_burden_cols <- paste0("SAMPLE_", c(
-    paste0(required_markers, "_HYPER"),
-    paste0(required_markers, "_HYPO")
-  ))
+  # AI-248: composed once in helper-burden.R, where the aggregation each class
+  # produces by default is spelled out.
+  required_burden_cols <- .burden_cols
   required_cols <- c("Sample_ID", required_burden_cols, "SAMPLE_N_PROBES")
 
   missing_cols <- setdiff(required_cols, colnames(df))

--- a/vignettes/association-analysis.Rmd
+++ b/vignettes/association-analysis.Rmd
@@ -109,7 +109,7 @@ Any semseeker output metric can be the dependent variable in `formula`:
 | `DELTARP` | `DELTAR` discretised into equal-width bins, each assigned an integer rank weight (default 4 bins) |
 | `DELTAQ` | `DELTAS` discretised into quantile bins, each assigned an integer rank weight |
 | `DELTARQ` | `DELTAR` discretised into quantile bins, each assigned an integer rank weight (default 4 bins) |
-| `SIGNAL_MEAN` | Per-probe mean methylation signal (marker `SIGNAL`, figure `MEAN`) |
+| `SIGNAL` | Per-probe methylation signal; its figure is the scale of the value — `BETA` for a proportion bounded in [0,1], `MVALUE` for the logit-transformed one |
 
 <hr>
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -288,7 +288,7 @@ Data/
 ├── SAMPLEID_MUTATIONS_HYPER.bed      ← probe-level hypermethylated mutations
 ├── SAMPLEID_LESIONS_HYPO.bed         ← genomic lesion clusters (hypo)
 ├── SAMPLEID_LESIONS_HYPER.bed        ← genomic lesion clusters (hyper)
-├── SAMPLEID_SIGNAL_MEAN.PROBE.bedgraph
+├── SAMPLE_GROUP/SIGNAL_BETA/SAMPLEID_SIGNAL_BETA.bedgraph.gz
 └── ...
 ```
 
@@ -296,15 +296,23 @@ Population-level pivot tables aggregate all samples per marker:
 
 ```
 Data/Pivots/
-├── SIGNAL/SIGNAL_MEAN_PROBE_WHOLE_hg19.parquet       ← mean signal per probe, all samples
-├── MUTATIONS/MUTATIONS_HYPO_PROBE_WHOLE_hg19.parquet
-├── DELTARP/DELTARP_HYPER_GENE_WHOLE_hg19.parquet     ← DELTARP (hyper) per gene, all samples
+├── SIGNAL/SIGNAL_BETA_PROBE_WHOLE_HG19.parquet       ← signal per probe, all samples
+├── MUTATIONS/MUTATIONS_HYPO_PROBE_WHOLE_HG19.parquet
+├── DELTARP/DELTARP_HYPER_GENE_WHOLE_HG19.parquet     ← DELTARP (hyper) per gene, all samples
 └── ...
 ```
 
-Pivot file names follow `<MARKER>_<FIGURE>_<AREA>_<SUBAREA>_<genome_build>.parquet`
-under `Data/Pivots/<MARKER>/`. The marker name is invariant across aggregation
-levels — only the `AREA` segment (`PROBE`, `GENE`, `ISLAND`, …) changes.
+The `BETA` segment of the `SIGNAL` files is the **scale** of the value, not an
+operator: `BETA` for a proportion bounded in [0,1] and `MVALUE` for the
+logit-transformed one. A session on the M-value scale writes `SIGNAL_MVALUE_*`
+in the same places.
+
+Pivot file names follow
+`<MARKER>_<FIGURE>_<AREA>_<SUBAREA>[_<AGGREGATION>]_<GENOME_BUILD>.parquet`
+under `Data/Pivots/<MARKER>/`, uppercased. The `AGGREGATION` segment appears
+only where a scope carries several operators (`SUM`, `MEAN`, `MEDIAN`, …); the
+marker name is invariant across aggregation levels — only the `AREA` segment
+(`PROBE`, `GENE`, `ISLAND`, …) changes.
 
 ### Reading results
 
@@ -362,11 +370,11 @@ head(deltarp_gene[order(-deltarp_gene$mean_deltarp),
 ## Step 5 — Differential signal analysis
 
 Beyond mutation calling, semseeker also tracks the **raw methylation signal**
-per region via the `SIGNAL_MEAN` marker:
+per region via the `SIGNAL` marker:
 
 | Marker | File pattern | Description |
 |---|---|---|
-| `SIGNAL_MEAN` | `Pivots/SIGNAL/SIGNAL_MEAN_*.parquet` | Per-region mean beta value per sample |
+| `SIGNAL` | `Pivots/SIGNAL/SIGNAL_BETA_*.parquet` | Per-region signal per sample, on the scale of the session (`BETA`, or `MVALUE`) |
 
 This pivot table has exactly the same structure as the mutation/delta tables
 and can be passed directly to `association_analysis()` — allowing you to test
@@ -375,7 +383,7 @@ whether mean methylation differs by phenotype, without any mutation-calling step
 ```{r signal_analysis, eval=FALSE}
 # inference_details specifies the PREDICTOR and the test — not a model formula.
 # `independent_variable` is the phenotype column, `family_test` the statistical
-# test. The dependent marker (SIGNAL_MEAN, MUTATIONS, …) is NOT named here: it
+# test. The dependent marker (SIGNAL, MUTATIONS, …) is NOT named here: it
 # comes from the markers you ran through semseeker(); association_analysis()
 # iterates over them and reads the matching pivot tables internally.
 inference_details <- data.frame(


### PR DESCRIPTION
**Breaking change.** Column names, pivot file names and the shape of an inference request all change. Result folders produced by earlier versions recompute their pivots once.

## Why

A number produced by SEMseeker is the reduction of a set of genomic positions. While every marker admitted exactly one reduction — a count is summed, a continuous deviation averaged — the operator could stay implicit and `MARKER`/`FIGURE` identified the value. Since scopes were introduced the same sample, over the same positions, can produce a median, a mean, a variance and an IQR: those two coordinates no longer identify anything.

So the operator becomes an axis, and a quantity is identified by four coordinates:

```
SCOPE × MARKER × FIGURE × AGGREGATION
```

The reasoning, in full, is in `engineering-decisions.md` §5.10 and in `work-order-tassonomia-scope-marker-figure-aggregation.md` (documents repository).

## What changes

**Names.** One compositor for columns, one for pivot file names, and nothing else pastes them:

| before | after |
|---|---|
| `SAMPLE_MUTATIONS_HYPER` | `SAMPLE_MUTATIONS_HYPER_SUM` |
| `SAMPLE_DELTAS_HYPO` | `SAMPLE_DELTAS_HYPO_MEAN` |
| `SAMPLE_MEDIAN` | `SAMPLE_SIGNAL_BETA_MEDIAN` |
| `MUTATIONS_HYPER_CHR_CYTOBAND_hg19.parquet` | `MUTATIONS_HYPER_CHR_CYTOBAND_SUM_hg19.parquet` |
| `SAMPLE_N_PROBES` | unchanged — a property of the scope, not of a marker |

**The figure of `SIGNAL` is the scale**, `BETA` or `MVALUE`. It used to be `MEAN`, a placeholder that made the key unique while naming a way of aggregating — which now has an axis of its own. A beta run and an M-value run no longer write the same pivot file name and overwrite each other. WGBS, ONT and PacBio stay `BETA`: a methylation fraction from reads is the same bounded scale as an array beta value, and the package compares the two on purpose.

**Aggregation in the pivot name is a guarantee, not a cost.** The name used to say nothing about which operator had produced the file, so an existing pivot was reused on trust. That was fine with one operator per marker; with several it is the worst kind of bug, silent, because the file is there and the run does not complain while a mean is consumed as a sum. The one-off recompute buys identity.

**Requests must name the reduction.** `inference_details$aggregation` is required. A malformed request — none given, or a name outside the taxonomy — stops the run. An impossible one — a legal aggregation that no marker of the run admits, the median of a 0/1 marker say — drops that row with a warning naming it and lets the others proceed. A partially admissible request runs on the combinations that exist and names those it skips. The check runs at the entrance of `association_analysis()`, before any result is written.

**Two classes decide what is admissible.** Continuous markers (`SIGNAL`, `DELTAS`, `DELTAR`) take the full descriptor set. Counts take the sum — the burden — and the mean — the density, the only form comparable across regions of different size. Their median and IQR are degenerate on a vector of zeros and ones. The two modes assume a bounded bimodal scale and exist for the beta-valued signal alone.

**`markers` means one thing for every marker,** `SIGNAL` included: a run that does not ask for it gets no signal descriptors. `N_PROBES` does not depend on it — reading the signal pivot to count positions is not the same as producing that marker's columns.

## Consequences to review

- `AGGREGATION` is part of the row identity: the grouping in `assoc_analysis_save_results` (whose `summarise(max)` would otherwise fuse the median and the mean of one scope into a single row), the depth=1 resume match, and the cross-study overlap groupings.
- Region scopes now carry the signal descriptors too — `GENE_TSS1500_SIGNAL_BETA_MEDIAN` is the per-sample median restricted to a region class, which was the point of the exercise.
- Still declared but **not wired**: selecting a pivot by aggregation at depth 2/3. The request validates, the per-instance consumption does not use it yet.

## Verification

Local suites on macOS, no failures: `test-0-taxonomy` 52, `test-0-sample-stats-sibling` 61, `test-8-burden-integration` 54, `test-7-association_analysis` 38.
